### PR TITLE
ci: update release and remove generate docs

### DIFF
--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -6,11 +6,12 @@ run-name: Provider Tests ${{ github.sha }} by @${{ github.actor }}
 # Optionally, you can turn it on using a schedule for regular testing.
 on:
   pull_request:
-    paths-ignore:
-      - "README.md"
+    paths:
+      - "internal/**.go"
   push:
-    paths-ignore:
-      - "README.md"
+    branches: [main]
+    paths:
+      - "internal/**.go"
 
 # Testing only needs permissions to read the repository contents.
 permissions:
@@ -34,28 +35,6 @@ jobs:
         with:
           version: latest
 
-  generate:
-    if: startsWith(github.ref, 'refs/tags/')
-    name: Generate
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
-        with:
-          go-version-file: "go.mod"
-          cache: true
-      # Temporarily download Terraform 1.8 prerelease for function documentation support.
-      # When Terraform 1.8.0 final is released, this can be removed.
-      - uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
-        with:
-          terraform_version: "1.8.0-alpha20240216"
-          terraform_wrapper: false
-      - run: go generate ./...
-      - name: git diff
-        run: |
-          git diff --compact-summary --exit-code || \
-            (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
-
   # Run acceptance tests in a matrix with Terraform CLI versions
   test:
     name: Terraform Provider Acceptance Tests
@@ -67,11 +46,8 @@ jobs:
       matrix:
         # list whatever Terraform versions here you would like to support
         terraform:
-          - "1.0.*"
-          - "1.1.*"
-          - "1.2.*"
-          - "1.3.*"
-          - "1.4.*"
+          - "1.8.*"
+          - "1.9.*"
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
@@ -83,7 +59,4 @@ jobs:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
       - run: go mod download
-      - env:
-          TF_ACC: "1"
-        run: go test -v -cover ./internal/provider/
-        timeout-minutes: 10
+      - run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,8 @@ run-name: Release ${{ github.sha }} by @${{ github.actor }}
 
 on:
   push:
-    branches: [main]
-    paths:
-      - "internal/**.go"
+    tags:
+      - "v*"
 
 # Releases need permissions to read and write the repository contents.
 # GitHub considers creating releases and uploading assets as writing contents.

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ default: help
 
 .PHONY: testacc
 testacc: ## Run acceptance tests
-	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
+	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 10m
 
 .PHONY: build ## Build the provider for all supported architectures
 build: build-amd64 build-arm64


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
- Update MAKEFILE to reduce `go test` timeout
- Update release pipeline to only trigger on push to tags
- Update testing pipeline to run on all changes to `.go` files and remove the documentation generation step
- Coincides with updated GPG key and passphrase in Repository secrets