### PR TITLE
fix: add support for schema json normalization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,12 @@ go 1.21.0
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.19.4
 	github.com/hashicorp/terraform-plugin-framework v1.10.0
+	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.1.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.13.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.9.0
 	github.com/riferrei/srclient v0.6.0
-	github.com/testcontainers/testcontainers-go v0.32.0
 	github.com/testcontainers/testcontainers-go/modules/redpanda v0.32.0
 
 )
@@ -103,6 +103,7 @@ require (
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
+	github.com/testcontainers/testcontainers-go v0.32.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/hashicorp/terraform-plugin-docs v0.19.4 h1:G3Bgo7J22OMtegIgn8Cd/CaSey
 github.com/hashicorp/terraform-plugin-docs v0.19.4/go.mod h1:4pLASsatTmRynVzsjEhbXZ6s7xBlUw/2Kt0zfrq8HxA=
 github.com/hashicorp/terraform-plugin-framework v1.10.0 h1:xXhICE2Fns1RYZxEQebwkB2+kXouLC932Li9qelozrc=
 github.com/hashicorp/terraform-plugin-framework v1.10.0/go.mod h1:qBXLDn69kM97NNVi/MQ9qgd1uWWsVftGSnygYG1tImM=
+github.com/hashicorp/terraform-plugin-framework-jsontypes v0.1.0 h1:b8vZYB/SkXJT4YPbT3trzE6oJ7dPyMy68+9dEDKsJjE=
+github.com/hashicorp/terraform-plugin-framework-jsontypes v0.1.0/go.mod h1:tP9BC3icoXBz72evMS5UTFvi98CiKhPdXF6yLs1wS8A=
 github.com/hashicorp/terraform-plugin-framework-validators v0.13.0 h1:bxZfGo9DIUoLLtHMElsu+zwqI4IsMZQBRRy4iLzZJ8E=
 github.com/hashicorp/terraform-plugin-framework-validators v0.13.0/go.mod h1:wGeI02gEhj9nPANU62F2jCaHjXulejm/X+af4PdZaNo=
 github.com/hashicorp/terraform-plugin-go v0.23.0 h1:AALVuU1gD1kPb48aPQUjug9Ir/125t+AAurhqphJ2Co=

--- a/internal/provider/data_source_schema.go
+++ b/internal/provider/data_source_schema.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/riferrei/srclient"
@@ -31,14 +32,14 @@ type schemaDataSource struct {
 
 // schemaDataSourceModel describes the data source data model.
 type schemaDataSourceModel struct {
-	ID                 types.String    `tfsdk:"id"`
-	Subject            types.String    `tfsdk:"subject"`
-	Schema             jsontypes.Exact `tfsdk:"schema"`
-	SchemaID           types.Int64     `tfsdk:"schema_id"`
-	SchemaType         types.String    `tfsdk:"schema_type"`
-	Version            types.Int64     `tfsdk:"version"`
-	Reference          types.List      `tfsdk:"reference"`
-	CompatibilityLevel types.String    `tfsdk:"compatibility_level"`
+	ID                 types.String         `tfsdk:"id"`
+	Subject            types.String         `tfsdk:"subject"`
+	Schema             jsontypes.Normalized `tfsdk:"schema"`
+	SchemaID           types.Int64          `tfsdk:"schema_id"`
+	SchemaType         types.String         `tfsdk:"schema_type"`
+	Version            types.Int64          `tfsdk:"version"`
+	Reference          types.List           `tfsdk:"reference"`
+	CompatibilityLevel types.String         `tfsdk:"compatibility_level"`
 }
 
 // Metadata returns the data source type name.
@@ -64,7 +65,7 @@ func (d *schemaDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 			"schema": schema.StringAttribute{
 				Description: "The schema string.",
 				Computed:    true,
-				CustomType:  jsontypes.ExactType{},
+				CustomType:  jsontypes.NormalizedType{},
 			},
 			"schema_id": schema.Int64Attribute{
 				Description: "The ID of the schema.",
@@ -174,7 +175,7 @@ func (d *schemaDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	}
 
 	// Map response body to schema data source model
-	outputs := mapSchemaToOutputs(subject, schema, compatibilityLevel)
+	outputs := d.mapSchemaToOutputs(subject, schema, compatibilityLevel, &resp.Diagnostics)
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, outputs)
@@ -198,11 +199,22 @@ func (d *schemaDataSource) fetchCompatibilityLevel(subject string) (*srclient.Co
 }
 
 // mapSchemaToOutputs maps the schema and compatibility level to the schema data source model.
-func mapSchemaToOutputs(subject string, schema *srclient.Schema, compatibilityLevel *srclient.CompatibilityLevel) schemaDataSourceModel {
+func (d *schemaDataSource) mapSchemaToOutputs(subject string, schema *srclient.Schema,
+	compatibilityLevel *srclient.CompatibilityLevel, diagnostics *diag.Diagnostics) schemaDataSourceModel {
+	// Normalize the schema string
+	normalizedSchema, err := NormalizeJSON(schema.Schema(), diagnostics)
+	if err != nil {
+		diagnostics.AddError(
+			"Normalization Error",
+			fmt.Sprintf("Could not normalize schema: %s", err),
+		)
+		return schemaDataSourceModel{}
+	}
+
 	return schemaDataSourceModel{
 		ID:                 types.StringValue(subject),
 		Subject:            types.StringValue(subject),
-		Schema:             jsontypes.NewExactValue(schema.Schema()),
+		Schema:             jsontypes.NewNormalizedValue(normalizedSchema),
 		SchemaID:           types.Int64Value(int64(schema.ID())),
 		SchemaType:         types.StringValue(FromSchemaType(schema.SchemaType())),
 		Version:            types.Int64Value(int64(schema.Version())),

--- a/internal/provider/data_source_schema.go
+++ b/internal/provider/data_source_schema.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -30,14 +31,14 @@ type schemaDataSource struct {
 
 // schemaDataSourceModel describes the data source data model.
 type schemaDataSourceModel struct {
-	ID                 types.String `tfsdk:"id"`
-	Subject            types.String `tfsdk:"subject"`
-	Schema             types.String `tfsdk:"schema"`
-	SchemaID           types.Int64  `tfsdk:"schema_id"`
-	SchemaType         types.String `tfsdk:"schema_type"`
-	Version            types.Int64  `tfsdk:"version"`
-	Reference          types.List   `tfsdk:"reference"`
-	CompatibilityLevel types.String `tfsdk:"compatibility_level"`
+	ID                 types.String    `tfsdk:"id"`
+	Subject            types.String    `tfsdk:"subject"`
+	Schema             jsontypes.Exact `tfsdk:"schema"`
+	SchemaID           types.Int64     `tfsdk:"schema_id"`
+	SchemaType         types.String    `tfsdk:"schema_type"`
+	Version            types.Int64     `tfsdk:"version"`
+	Reference          types.List      `tfsdk:"reference"`
+	CompatibilityLevel types.String    `tfsdk:"compatibility_level"`
 }
 
 // Metadata returns the data source type name.
@@ -63,6 +64,7 @@ func (d *schemaDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 			"schema": schema.StringAttribute{
 				Description: "The schema string.",
 				Computed:    true,
+				CustomType:  jsontypes.ExactType{},
 			},
 			"schema_id": schema.Int64Attribute{
 				Description: "The ID of the schema.",
@@ -200,7 +202,7 @@ func mapSchemaToOutputs(subject string, schema *srclient.Schema, compatibilityLe
 	return schemaDataSourceModel{
 		ID:                 types.StringValue(subject),
 		Subject:            types.StringValue(subject),
-		Schema:             types.StringValue(schema.Schema()),
+		Schema:             jsontypes.NewExactValue(schema.Schema()),
 		SchemaID:           types.Int64Value(int64(schema.ID())),
 		SchemaType:         types.StringValue(FromSchemaType(schema.SchemaType())),
 		Version:            types.Int64Value(int64(schema.Version())),

--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -34,14 +35,14 @@ type schemaResource struct {
 
 // schemaResourceModel describes the resource data model.
 type schemaResourceModel struct {
-	ID                 types.String `tfsdk:"id"`
-	Subject            types.String `tfsdk:"subject"`
-	Schema             types.String `tfsdk:"schema"`
-	SchemaID           types.Int64  `tfsdk:"schema_id"`
-	SchemaType         types.String `tfsdk:"schema_type"`
-	Version            types.Int64  `tfsdk:"version"`
-	Reference          types.List   `tfsdk:"references"`
-	CompatibilityLevel types.String `tfsdk:"compatibility_level"`
+	ID                 types.String         `tfsdk:"id"`
+	Subject            types.String         `tfsdk:"subject"`
+	Schema             jsontypes.Normalized `tfsdk:"schema"`
+	SchemaID           types.Int64          `tfsdk:"schema_id"`
+	SchemaType         types.String         `tfsdk:"schema_type"`
+	Version            types.Int64          `tfsdk:"version"`
+	Reference          types.List           `tfsdk:"references"`
+	CompatibilityLevel types.String         `tfsdk:"compatibility_level"`
 }
 
 // Metadata returns the resource type name.
@@ -57,7 +58,7 @@ func (r *schemaResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 		Description:         "Manages a schema in the Schema Registry.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Description: "UID for the schema, which is the subject name.",
+				Description: "The globally unique ID of the schema.",
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -71,8 +72,12 @@ func (r *schemaResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				},
 			},
 			"schema": schema.StringAttribute{
-				Description: "The schema string.",
+				Description: "The schema definition.",
 				Required:    true,
+				CustomType:  jsontypes.NormalizedType{},
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(2),
+				},
 			},
 			"schema_id": schema.Int64Attribute{
 				Description: "The ID of the schema.",
@@ -104,10 +109,16 @@ func (r *schemaResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						"name": schema.StringAttribute{
 							Description: "The referenced schema name.",
 							Required:    true,
+							Validators: []validator.String{
+								stringvalidator.LengthAtLeast(1),
+							},
 						},
 						"subject": schema.StringAttribute{
 							Description: "The referenced schema subject.",
 							Required:    true,
+							Validators: []validator.String{
+								stringvalidator.LengthAtLeast(1),
+							},
 						},
 						"version": schema.Int64Attribute{
 							Description: "The referenced schema version.",
@@ -117,7 +128,7 @@ func (r *schemaResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				},
 			},
 			"compatibility_level": schema.StringAttribute{
-				Description: "The compatibility level of the schema. Default is FORWARD_TRANSITIVE.",
+				Description: "The compatibility level of the schema.",
 				Optional:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOf(
@@ -203,7 +214,7 @@ func (r *schemaResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	// Map response body to schema
 	plan.ID = plan.Subject
-	plan.Schema = types.StringValue(schema.Schema())
+	plan.Schema = jsontypes.NewNormalizedValue(schema.Schema())
 	plan.SchemaID = types.Int64Value(int64(schema.ID()))
 	plan.SchemaType = types.StringValue(schemaTypeStr)
 	plan.Version = types.Int64Value(1) // Set the version to 1 for new schema
@@ -239,7 +250,7 @@ func (r *schemaResource) Read(ctx context.Context, req resource.ReadRequest, res
 	schemaType := FromSchemaType(schema.SchemaType())
 
 	// Update state with refreshed values
-	state.Schema = types.StringValue(schema.Schema())
+	state.Schema = jsontypes.NewNormalizedValue(schema.Schema())
 	state.SchemaID = types.Int64Value(int64(schema.ID()))
 	state.SchemaType = types.StringValue(schemaType)
 	state.Version = types.Int64Value(int64(schema.Version()))
@@ -290,7 +301,7 @@ func (r *schemaResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	// Update state with refreshed values
-	plan.Schema = types.StringValue(schema.Schema())
+	plan.Schema = jsontypes.NewNormalizedValue(schema.Schema())
 	plan.SchemaID = types.Int64Value(int64(schema.ID()))
 	plan.Version = types.Int64Value(int64(schema.Version()))
 	plan.Reference = FromRegistryReferences(schema.References())
@@ -357,7 +368,7 @@ func (r *schemaResource) ImportState(ctx context.Context, req resource.ImportSta
 	state := schemaResourceModel{
 		ID:                 types.StringValue(subject),
 		Subject:            types.StringValue(subject),
-		Schema:             types.StringValue(schema.Schema()),
+		Schema:             jsontypes.NewNormalizedValue(schema.Schema()),
 		SchemaID:           types.Int64Value(int64(schema.ID())),
 		SchemaType:         types.StringValue(schemaType),
 		Version:            types.Int64Value(int64(schema.Version())),

--- a/internal/provider/resource_schema_test.go
+++ b/internal/provider/resource_schema_test.go
@@ -4,34 +4,59 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAccSchemaResource_CreateReadImportUpdate(t *testing.T) {
+const (
+	initialSchema = `{
+    "type": "record",
+    "name": "Test",
+    "fields": [
+        {
+            "name": "f1",
+            "type": "string"
+        }
+    ]
+}`
+
+	updatedSchema = `{
+    "type": "record",
+    "name": "TestUpdated",
+    "fields": [
+        {
+            "name": "f1",
+            "type": "string"
+        },
+        {
+            "name": "f2",
+            "type": "int"
+        }
+    ]
+}`
+)
+
+func TestAccSchemaResource_basic(t *testing.T) {
 	subjectName := acctest.RandomWithPrefix("tf-acc-test")
-	referenceSubjectName := acctest.RandomWithPrefix("tf-acc-test-ref")
+	ref01 := acctest.RandomWithPrefix("tf-acc-test-ref")
 	resourceName := "schemaregistry_schema.test_01"
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Create and Read testing with references
+			// Create, Read, ImportState testing
 			{
-				Config: testAccSchemaResourceConfig_single(subjectName, referenceSubjectName),
+				Config: testAccSchemaResourceConfig_single(subjectName, ref01),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify schema attributes
 					resource.TestCheckResourceAttr(resourceName, "subject", subjectName),
-					resource.TestCheckResourceAttr(resourceName, "schema", "{\"type\":\"record\",\"name\":\"Test\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"}]}"),
+					resource.TestCheckResourceAttr(resourceName, "schema",
+						jsontypes.NewNormalizedValue(initialSchema).ValueString()),
 					resource.TestCheckResourceAttr(resourceName, "schema_type", "avro"),
 					resource.TestCheckResourceAttr(resourceName, "compatibility_level", "NONE"),
 					resource.TestCheckResourceAttrSet(resourceName, "schema_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "version"),
-					// Verify references attributes
-					resource.TestCheckResourceAttr(resourceName, "references.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "references.0.name", "TestRef"),
-					resource.TestCheckResourceAttr(resourceName, "references.0.subject", referenceSubjectName),
-					resource.TestCheckResourceAttr(resourceName, "references.0.version", "1"),
 				),
 			},
 			// ImportState testing
@@ -42,21 +67,55 @@ func TestAccSchemaResource_CreateReadImportUpdate(t *testing.T) {
 				// No attributes to ignore during import
 				ImportStateVerifyIgnore: []string{},
 			},
-			// Update and Read testing with references
+			// Update testing
 			{
-				Config: testAccSchemaResourceConfig_singleUpdate(subjectName, referenceSubjectName),
+				Config: testAccSchemaResourceConfig_singleUpdate(subjectName, ref01),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify updated schema attributes
 					resource.TestCheckResourceAttr(resourceName, "subject", subjectName),
-					resource.TestCheckResourceAttr(resourceName, "schema", "{\"type\":\"record\",\"name\":\"TestUpdated\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"},{\"name\":\"f2\",\"type\":\"int\"}]}"),
+					resource.TestCheckResourceAttr(resourceName, "schema",
+						jsontypes.NewNormalizedValue(updatedSchema).ValueString()),
 					resource.TestCheckResourceAttr(resourceName, "schema_type", "avro"),
 					resource.TestCheckResourceAttr(resourceName, "compatibility_level", "BACKWARD"),
 					resource.TestCheckResourceAttrSet(resourceName, "schema_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "version"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSchemaResource_withReferences(t *testing.T) {
+	subjectName := acctest.RandomWithPrefix("tf-acc-test")
+	ref01 := acctest.RandomWithPrefix("tf-acc-test-ref")
+	resourceName := "schemaregistry_schema.test_01"
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSchemaResourceConfig_single(subjectName, ref01),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify references attributes
+					resource.TestCheckResourceAttr(resourceName, "references.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "references.0.name", "TestRef01"),
+					resource.TestCheckResourceAttr(resourceName, "references.0.subject", ref01),
+					resource.TestCheckResourceAttr(resourceName, "references.0.version", "1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+			{
+				Config: testAccSchemaResourceConfig_singleUpdate(subjectName, ref01),
+				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify updated references attributes
 					resource.TestCheckResourceAttr(resourceName, "references.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "references.0.name", "TestRefUpdated"),
-					resource.TestCheckResourceAttr(resourceName, "references.0.subject", referenceSubjectName),
+					resource.TestCheckResourceAttr(resourceName, "references.0.subject", ref01),
 					resource.TestCheckResourceAttr(resourceName, "references.0.version", "2"),
 				),
 			},
@@ -79,34 +138,54 @@ provider "schemaregistry" {
 	)
 }
 
-func testAccSchemaResourceConfig_single(subject string, referenceSubject string) string {
+func testAccSchemaResourceConfig_single(subject, ref01 string) string {
 	const singleTemplate = `
 resource "schemaregistry_schema" "ref_01" {
   subject              = "%s"
   schema_type          = "avro"
   compatibility_level  = "NONE"
-  schema               = "{\"type\":\"record\",\"name\":\"Test\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"}]}"
+  schema               = <<EOF
+{
+  "type": "record",
+  "name": "Test",
+  "fields": [
+    {
+      "name": "f1",
+      "type": "string"
+    }
+  ]
+}
+EOF
 }
 
 resource "schemaregistry_schema" "test_01" {
   subject              = "%s"
   schema_type          = "avro"
   compatibility_level  = "NONE"
-  schema               = "{\"type\":\"record\",\"name\":\"Test\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"}]}"
-  references = [
+  schema               = jsonencode({
+  "type": "record",
+  "name": "Test",
+  "fields": [
     {
-      name    = "TestRef"
+      "name": "f1",
+      "type": "string"
+    }
+  ]
+})
+references = [
+    {
+      name    = "TestRef01"
       subject = schemaregistry_schema.ref_01.subject
       version = schemaregistry_schema.ref_01.version
-    }
+    },
   ]
 }
 `
 	return ConfigCompose(testAccSchemaResourceConfig_base(),
-		fmt.Sprintf(singleTemplate, referenceSubject, subject))
+		fmt.Sprintf(singleTemplate, ref01, subject))
 }
 
-func testAccSchemaResourceConfig_singleUpdate(subject string, referenceSubject string) string {
+func testAccSchemaResourceConfig_singleUpdate(subject, ref01 string) string {
 	const updateTemplate = `
 resource "schemaregistry_schema" "ref_01" {
   subject              = "%s"
@@ -130,5 +209,5 @@ resource "schemaregistry_schema" "test_01" {
 }
 `
 	return ConfigCompose(testAccSchemaResourceConfig_base(),
-		fmt.Sprintf(updateTemplate, referenceSubject, subject))
+		fmt.Sprintf(updateTemplate, ref01, subject))
 }

--- a/internal/provider/resource_schema_test.go
+++ b/internal/provider/resource_schema_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -51,8 +50,7 @@ func TestAccSchemaResource_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify schema attributes
 					resource.TestCheckResourceAttr(resourceName, "subject", subjectName),
-					resource.TestCheckResourceAttr(resourceName, "schema",
-						jsontypes.NewNormalizedValue(initialSchema).ValueString()),
+					resource.TestCheckResourceAttr(resourceName, "schema", NormalizedJSON(initialSchema)),
 					resource.TestCheckResourceAttr(resourceName, "schema_type", "avro"),
 					resource.TestCheckResourceAttr(resourceName, "compatibility_level", "NONE"),
 					resource.TestCheckResourceAttrSet(resourceName, "schema_id"),
@@ -61,10 +59,9 @@ func TestAccSchemaResource_basic(t *testing.T) {
 			},
 			// ImportState testing
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				// No attributes to ignore during import
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{},
 			},
 			// Update testing
@@ -73,8 +70,7 @@ func TestAccSchemaResource_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify updated schema attributes
 					resource.TestCheckResourceAttr(resourceName, "subject", subjectName),
-					resource.TestCheckResourceAttr(resourceName, "schema",
-						jsontypes.NewNormalizedValue(updatedSchema).ValueString()),
+					resource.TestCheckResourceAttr(resourceName, "schema", NormalizedJSON(updatedSchema)),
 					resource.TestCheckResourceAttr(resourceName, "schema_type", "avro"),
 					resource.TestCheckResourceAttr(resourceName, "compatibility_level", "BACKWARD"),
 					resource.TestCheckResourceAttrSet(resourceName, "schema_id"),
@@ -191,14 +187,36 @@ resource "schemaregistry_schema" "ref_01" {
   subject              = "%s"
   schema_type          = "avro"
   compatibility_level  = "NONE"
-  schema               = "{\"type\":\"record\",\"name\":\"TestRefUpdated\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"}]}"
+  schema               = jsonencode({
+    "type": "record",
+    "name": "TestRefUpdated",
+    "fields": [
+      {
+        "name": "f1",
+        "type": "string"
+      }
+    ]
+  })
 }
 
 resource "schemaregistry_schema" "test_01" {
   subject              = "%s"
   schema_type          = "avro"
   compatibility_level  = "BACKWARD"
-  schema               = "{\"type\":\"record\",\"name\":\"TestUpdated\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"},{\"name\":\"f2\",\"type\":\"int\"}]}"
+  schema               = jsonencode({
+    "type": "record",
+    "name": "TestUpdated",
+    "fields": [
+      {
+        "name": "f1",
+        "type": "string"
+      },
+      {
+        "name": "f2",
+        "type": "int"
+      }
+    ]
+  })
   references = [
     {
       name    = "TestRefUpdated"

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -1,8 +1,12 @@
 package provider
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
 // getEnvOrDefault returns the value of the configuration or the environment variable.
@@ -22,4 +26,38 @@ func ConfigCompose(config ...string) string {
 	}
 
 	return str.String()
+}
+
+// NormalizeJSON normalizes a JSON string by unmarshaling it into a Go data structure and then marshaling it back to a
+// JSON string. If diagnostics is provided, errors encountered during the process are added to it.
+func NormalizeJSON(jsonString string, diagnostics *diag.Diagnostics) (string, error) {
+	var jsonData interface{}
+	err := json.Unmarshal([]byte(jsonString), &jsonData)
+	if err != nil {
+		diagnostics.AddError(
+			"Invalid JSON",
+			fmt.Sprintf("Error unmarshaling JSON: %s", err),
+		)
+		return "", err
+	}
+
+	normalizedBytes, err := json.Marshal(jsonData)
+	if err != nil {
+		diagnostics.AddError(
+			"Normalization Error",
+			fmt.Sprintf("Error marshaling JSON: %s", err),
+		)
+		return "", err
+	}
+
+	return string(normalizedBytes), nil
+}
+
+// NormalizedJSON is a JSON normalization helper function for tests.
+func NormalizedJSON(jsonString string) string {
+	normalized, err := NormalizeJSON(jsonString, nil)
+	if err != nil {
+		return ""
+	}
+	return normalized
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

This change introduces JSON normalization and a custom schema attribute type `jsontypes.NormalizedType{}` to resolve an issue with importing schema resources into state:

```
│ Error: Provider produced inconsistent result after apply 
|
| When applying changes to
│ schemaregistry_schema.9F0719FE,
"provider[\"registry.terraform.io/cultureamp/schemaregistry\"]"
│ produced an unexpected new value: .schema: was cty.StringVal("{ ... }")
│ but now cty.StringVal("{ ... }")
```

Tests have been slightly refactored and updated to handle normalization.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
TF_ACC=1 go test ./... -v  -timeout 10m
?       github.com/cultureamp/terraform-provider-schemaregistry [no test files]
2024/07/29 09:44:43 github.com/testcontainers/testcontainers-go - Connected to docker: 
  Server Version: 26.1.4
  API Version: 1.45
  Operating System: OrbStack
  Total Memory: 7930 MB
  Testcontainers for Go Version: v0.32.0
  Resolved Docker Host: unix:///var/run/docker.sock
  Resolved Docker Socket Path: /var/run/docker.sock
  Test SessionID: 8c19b6deaa4012c057ff3308dbc539eb6e3a358a4d87bb88d16530a025d5afe2
  Test ProcessID: ef50e3d2-62ac-4bcc-97e5-9288d168e91b
2024/07/29 09:44:43 🐳 Creating container for image testcontainers/ryuk:0.7.0
2024/07/29 09:44:43 ✅ Container created: bf58dfadea2e
2024/07/29 09:44:43 🐳 Starting container: bf58dfadea2e
2024/07/29 09:44:43 ✅ Container started: bf58dfadea2e
2024/07/29 09:44:43 ⏳ Waiting for container id bf58dfadea2e image: testcontainers/ryuk:0.7.0. Waiting for: &{Port:8080/tcp timeout:<nil> PollInterval:100ms}
2024/07/29 09:44:44 🔔 Container is ready: bf58dfadea2e
2024/07/29 09:44:44 🐳 Creating container for image docker.redpanda.com/redpandadata/redpanda:v23.3.3
2024/07/29 09:44:44 ✅ Container created: 975b04fe51f3
2024/07/29 09:44:44 🐳 Starting container: 975b04fe51f3
2024/07/29 09:44:44 ✅ Container started: 975b04fe51f3
2024/07/29 09:44:44 🔔 Container is ready: 975b04fe51f3
=== RUN   TestAccSchemaDataSource_basic
--- PASS: TestAccSchemaDataSource_basic (1.75s)
=== RUN   TestAccSchemaDataSource_multipleVersions
--- PASS: TestAccSchemaDataSource_multipleVersions (0.90s)
=== RUN   TestAccSchemaResource_basic
=== PAUSE TestAccSchemaResource_basic
=== RUN   TestAccSchemaResource_withReferences
=== PAUSE TestAccSchemaResource_withReferences
=== CONT  TestAccSchemaResource_basic
=== CONT  TestAccSchemaResource_withReferences
--- PASS: TestAccSchemaResource_basic (0.82s)
--- PASS: TestAccSchemaResource_withReferences (0.83s)
PASS
ok      github.com/cultureamp/terraform-provider-schemaregistry/internal/provider   

...
```
