### PR TITLE
feat: enforce uppercase `schema_type` values for consistency

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ provider "schemaregistry" {
 
 resource "schemaregistry_schema" "example" {
   subject             = "example"
-  schema_type         = "avro"
+  schema_type         = "AVRO"
   compatibility_level = "FORWARD_TRANSITIVE"
   schema              = "example"
 }

--- a/docs/resources/schemaregistry_schema.md
+++ b/docs/resources/schemaregistry_schema.md
@@ -15,7 +15,7 @@ Provides a Schema Registry Schema resource.
 ```hcl
 resource "schemaregistry_schema" "example" {
   subject             = "example"
-  schema_type         = "avro"
+  schema_type         = "AVRO"
   compatibility_level = "FORWARD_TRANSITIVE"
   schema              = "example"
 

--- a/examples/resources/schemaregistry_schema/resource.tf
+++ b/examples/resources/schemaregistry_schema/resource.tf
@@ -1,6 +1,6 @@
 resource "schemaregistry_schema" "example" {
   subject             = "example-subject"
   schema              = "{\"type\":\"record\",\"name\":\"Test\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"}]}"
-  schema_type         = "avro"
+  schema_type         = "AVRO"
   compatibility_level = "FORWARD_TRANSITIVE"
 }

--- a/internal/provider/data_source_schema.go
+++ b/internal/provider/data_source_schema.go
@@ -76,9 +76,9 @@ func (d *schemaDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 				Computed:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOf(
-						"avro",
-						"json",
-						"protobuf",
+						"AVRO",
+						"JSON",
+						"PROTOBUF",
 					),
 				},
 			},

--- a/internal/provider/data_source_schema_test.go
+++ b/internal/provider/data_source_schema_test.go
@@ -20,7 +20,7 @@ func TestAccSchemaDataSource_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "subject", subjectName),
 					resource.TestCheckResourceAttr(datasourceName, "schema", NormalizedJSON(initialSchema)),
-					resource.TestCheckResourceAttr(datasourceName, "schema_type", "avro"),
+					resource.TestCheckResourceAttr(datasourceName, "schema_type", "AVRO"),
 					resource.TestCheckResourceAttr(datasourceName, "compatibility_level", "NONE"),
 				),
 			},
@@ -42,7 +42,7 @@ func TestAccSchemaDataSource_multipleVersions(t *testing.T) {
 					resource.TestCheckResourceAttrSet(datasourceName, "id"),
 					resource.TestCheckResourceAttr(datasourceName, "subject", subjectName),
 					resource.TestCheckResourceAttr(datasourceName, "schema", NormalizedJSON(initialSchema)),
-					resource.TestCheckResourceAttr(datasourceName, "schema_type", "avro"),
+					resource.TestCheckResourceAttr(datasourceName, "schema_type", "AVRO"),
 					resource.TestCheckResourceAttr(datasourceName, "compatibility_level", "NONE"),
 				),
 			},
@@ -53,7 +53,7 @@ func TestAccSchemaDataSource_multipleVersions(t *testing.T) {
 					resource.TestCheckResourceAttrSet(datasourceName, "id"),
 					resource.TestCheckResourceAttr(datasourceName, "subject", subjectName),
 					resource.TestCheckResourceAttr(datasourceName, "schema", NormalizedJSON(updatedSchema)),
-					resource.TestCheckResourceAttr(datasourceName, "schema_type", "avro"),
+					resource.TestCheckResourceAttr(datasourceName, "schema_type", "AVRO"),
 					resource.TestCheckResourceAttr(datasourceName, "compatibility_level", "BACKWARD"),
 				),
 			},
@@ -64,7 +64,7 @@ func TestAccSchemaDataSource_multipleVersions(t *testing.T) {
 					resource.TestCheckResourceAttrSet(datasourceName, "id"),
 					resource.TestCheckResourceAttr(datasourceName, "subject", subjectName),
 					resource.TestCheckResourceAttr(datasourceName, "schema", NormalizedJSON(updatedSchema)),
-					resource.TestCheckResourceAttr(datasourceName, "schema_type", "avro"),
+					resource.TestCheckResourceAttr(datasourceName, "schema_type", "AVRO"),
 					resource.TestCheckResourceAttr(datasourceName, "compatibility_level", "BACKWARD"),
 					resource.TestCheckResourceAttr(datasourceName, "version", "2"),
 				),
@@ -92,7 +92,7 @@ func testAccSchemaDataSourceConfig_single(subject string) string {
 	const singleTemplate = `
 resource "schemaregistry_schema" "test_01" {
   subject              = "%s"
-  schema_type          = "avro"
+  schema_type          = "AVRO"
   compatibility_level  = "NONE"
   schema               = jsonencode({
   "type": "record",
@@ -122,7 +122,7 @@ func testAccSchemaDataSourceConfig_update(subject string) string {
 	const updateTemplate = `
 resource "schemaregistry_schema" "test_01" {
   subject             = "%s"
-  schema_type         = "avro"
+  schema_type         = "AVRO"
   compatibility_level = "BACKWARD"
   schema              = jsonencode({
     type = "record",
@@ -156,7 +156,7 @@ func testAccSchemaDataSourceConfig_specificVersion(subject string, version int) 
 	const specificVersionTemplate = `
 resource "schemaregistry_schema" "test_01" {
   subject             = "%s"
-  schema_type         = "avro"
+  schema_type         = "AVRO"
   compatibility_level = "BACKWARD"
   schema              = jsonencode({
     type = "record",

--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -91,9 +91,9 @@ func (r *schemaResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				},
 				Validators: []validator.String{
 					stringvalidator.OneOf(
-						"avro",
-						"json",
-						"protobuf",
+						"AVRO",
+						"JSON",
+						"PROTOBUF",
 					),
 				},
 			},
@@ -526,18 +526,18 @@ func ToRegistryReferences(references types.List) []srclient.Reference {
 
 func FromSchemaType(schemaType *srclient.SchemaType) string {
 	if schemaType == nil {
-		return "avro"
+		return "AVRO"
 	}
 	return string(*schemaType)
 }
 
 func ToSchemaType(schemaType string) srclient.SchemaType {
 	switch schemaType {
-	case "avro":
+	case "AVRO":
 		return srclient.Avro
-	case "json":
+	case "JSON":
 		return srclient.Json
-	case "protobuf":
+	case "PROTOBUF":
 		return srclient.Protobuf
 	default:
 		return srclient.Avro
@@ -561,7 +561,7 @@ func FromCompatibilityLevelType(compatibilityLevel srclient.CompatibilityLevel) 
 	case srclient.FullTransitive:
 		return "FULL_TRANSITIVE"
 	default:
-		return "FORWARD_TRANSITIVE"
+		return "BACKWARD"
 	}
 }
 
@@ -582,6 +582,6 @@ func ToCompatibilityLevelType(compatibilityLevel string) srclient.CompatibilityL
 	case "FULL_TRANSITIVE":
 		return srclient.FullTransitive
 	default:
-		return srclient.ForwardTransitive
+		return srclient.Backward
 	}
 }

--- a/internal/provider/resource_schema_test.go
+++ b/internal/provider/resource_schema_test.go
@@ -51,7 +51,7 @@ func TestAccSchemaResource_basic(t *testing.T) {
 					// Verify schema attributes
 					resource.TestCheckResourceAttr(resourceName, "subject", subjectName),
 					resource.TestCheckResourceAttr(resourceName, "schema", NormalizedJSON(initialSchema)),
-					resource.TestCheckResourceAttr(resourceName, "schema_type", "avro"),
+					resource.TestCheckResourceAttr(resourceName, "schema_type", "AVRO"),
 					resource.TestCheckResourceAttr(resourceName, "compatibility_level", "NONE"),
 					resource.TestCheckResourceAttrSet(resourceName, "schema_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "version"),
@@ -71,7 +71,7 @@ func TestAccSchemaResource_basic(t *testing.T) {
 					// Verify updated schema attributes
 					resource.TestCheckResourceAttr(resourceName, "subject", subjectName),
 					resource.TestCheckResourceAttr(resourceName, "schema", NormalizedJSON(updatedSchema)),
-					resource.TestCheckResourceAttr(resourceName, "schema_type", "avro"),
+					resource.TestCheckResourceAttr(resourceName, "schema_type", "AVRO"),
 					resource.TestCheckResourceAttr(resourceName, "compatibility_level", "BACKWARD"),
 					resource.TestCheckResourceAttrSet(resourceName, "schema_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "version"),
@@ -138,7 +138,7 @@ func testAccSchemaResourceConfig_single(subject, ref01 string) string {
 	const singleTemplate = `
 resource "schemaregistry_schema" "ref_01" {
   subject              = "%s"
-  schema_type          = "avro"
+  schema_type          = "AVRO"
   compatibility_level  = "NONE"
   schema               = <<EOF
 {
@@ -156,7 +156,7 @@ EOF
 
 resource "schemaregistry_schema" "test_01" {
   subject              = "%s"
-  schema_type          = "avro"
+  schema_type          = "AVRO"
   compatibility_level  = "NONE"
   schema               = jsonencode({
   "type": "record",
@@ -185,7 +185,7 @@ func testAccSchemaResourceConfig_singleUpdate(subject, ref01 string) string {
 	const updateTemplate = `
 resource "schemaregistry_schema" "ref_01" {
   subject              = "%s"
-  schema_type          = "avro"
+  schema_type          = "AVRO"
   compatibility_level  = "NONE"
   schema               = jsonencode({
     "type": "record",
@@ -201,7 +201,7 @@ resource "schemaregistry_schema" "ref_01" {
 
 resource "schemaregistry_schema" "test_01" {
   subject              = "%s"
-  schema_type          = "avro"
+  schema_type          = "AVRO"
   compatibility_level  = "BACKWARD"
   schema               = jsonencode({
     "type": "record",


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

>[!WARNING]
> ❗ This is technically a breaking change as all `schema_type` values will need to be changed to uppercase. 


Updates `schema_type` attribute validation to match uppercase values, as a [convention](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#get--subjects-(string-%20subject)-versions-(versionId-%20version)-schema) of the upstream API. Documentation and examples have been updated to reflect this change.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

N/A

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
2024/08/12 17:42:03 🐳 Creating container for image docker.redpanda.com/redpandadata/redpanda:v23.3.3
2024/08/12 17:42:03 ✅ Container created: 61f9cf2a04f1
2024/08/12 17:42:03 🐳 Starting container: 61f9cf2a04f1
2024/08/12 17:42:03 ✅ Container started: 61f9cf2a04f1
2024/08/12 17:42:03 🔔 Container is ready: 61f9cf2a04f1
=== RUN   TestAccSchemaDataSource_basic
--- PASS: TestAccSchemaDataSource_basic (1.79s)
=== RUN   TestAccSchemaDataSource_multipleVersions
--- PASS: TestAccSchemaDataSource_multipleVersions (0.97s)
=== RUN   TestAccSchemaResource_basic
=== PAUSE TestAccSchemaResource_basic
=== RUN   TestAccSchemaResource_withReferences
=== PAUSE TestAccSchemaResource_withReferences
=== CONT  TestAccSchemaResource_basic
=== CONT  TestAccSchemaResource_withReferences
--- PASS: TestAccSchemaResource_basic (0.82s)
--- PASS: TestAccSchemaResource_withReferences (0.83s)
PASS
ok      github.com/cultureamp/terraform-provider-schemaregistry/internal/provider  
...
```
