### PR TITLE
feat: add support for optionally hard deleting schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ resource "schemaregistry_schema" "example" {
   subject              = "example"
   schema_type          = "AVRO"
   compatibility_level  = "NONE"
+  hard_delete          = false
   schema               = file("path/to/your/schema.avsc")
 
   # optional list of schema references

--- a/docs/resources/schemaregistry_schema.md
+++ b/docs/resources/schemaregistry_schema.md
@@ -17,6 +17,7 @@ resource "schemaregistry_schema" "example" {
   subject             = "example"
   schema_type         = "AVRO"
   compatibility_level = "FORWARD_TRANSITIVE"
+  hard_delete         = true
   schema              = "example"
 
   # optional list of schema references
@@ -37,8 +38,9 @@ The following arguments are supported:
 * `subject` - (Required) The subject related to the schema.
 * `schema_type` - (Required) The schema type.
 * `compatibility_level` - (Required) The schema compatibility level.
-* `schema` - (Required) The schema string.
+* `schema` - (Optional) The schema string.
 * `references` - (Optional) The referenced schema list.
+* `hard_delete` - (Optional) Controls whether the subject is soft or hard deleted.
 
 ## Attributes Reference
 

--- a/examples/resources/schemaregistry_schema/resource.tf
+++ b/examples/resources/schemaregistry_schema/resource.tf
@@ -3,4 +3,5 @@ resource "schemaregistry_schema" "example" {
   schema              = "{\"type\":\"record\",\"name\":\"Test\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"}]}"
   schema_type         = "AVRO"
   compatibility_level = "FORWARD_TRANSITIVE"
+  hard_delete         = true
 }

--- a/internal/provider/data_source_schema.go
+++ b/internal/provider/data_source_schema.go
@@ -40,10 +40,12 @@ type schemaDataSourceModel struct {
 	Version            types.Int64          `tfsdk:"version"`
 	Reference          types.List           `tfsdk:"reference"`
 	CompatibilityLevel types.String         `tfsdk:"compatibility_level"`
+	HardDelete         types.Bool           `tfsdk:"hard_delete"`
 }
 
 // Metadata returns the data source type name.
-func (d *schemaDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+func (d *schemaDataSource) Metadata(_ context.Context, req datasource.MetadataRequest,
+	resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_schema"
 }
 
@@ -55,7 +57,7 @@ func (d *schemaDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 		Description:         "Fetches a schema from the Schema Registry.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				Description: "UID for the schema, which is the subject name.",
+				Description: "The globally unique ID of the schema.",
 				Computed:    true,
 			},
 			"subject": schema.StringAttribute{
@@ -63,7 +65,7 @@ func (d *schemaDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 				Required:    true,
 			},
 			"schema": schema.StringAttribute{
-				Description: "The schema string.",
+				Description: "The schema definition.",
 				Computed:    true,
 				CustomType:  jsontypes.NormalizedType{},
 			},
@@ -107,7 +109,7 @@ func (d *schemaDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 				},
 			},
 			"compatibility_level": schema.StringAttribute{
-				Description: "The compatibility level of the schema. Default is FORWARD_TRANSITIVE.",
+				Description: "The compatibility level of the schema.",
 				Computed:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOf(
@@ -121,12 +123,17 @@ func (d *schemaDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 					),
 				},
 			},
+			"hard_delete": schema.BoolAttribute{
+				Description: "Controls whether a schema should be soft or hard deleted.",
+				Optional:    true,
+			},
 		},
 	}
 }
 
 // Configure adds the provider configured client to the data source.
-func (d *schemaDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+func (d *schemaDataSource) Configure(_ context.Context, req datasource.ConfigureRequest,
+	resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}

--- a/internal/provider/data_source_schema_test.go
+++ b/internal/provider/data_source_schema_test.go
@@ -94,6 +94,7 @@ resource "schemaregistry_schema" "test_01" {
   subject              = "%s"
   schema_type          = "AVRO"
   compatibility_level  = "NONE"
+  hard_delete          = false
   schema               = jsonencode({
   "type": "record",
   "name": "Test",
@@ -124,6 +125,7 @@ resource "schemaregistry_schema" "test_01" {
   subject             = "%s"
   schema_type         = "AVRO"
   compatibility_level = "BACKWARD"
+  hard_delete         = false
   schema              = jsonencode({
     type = "record",
     name = "TestUpdated",

--- a/internal/provider/resource_schema_test.go
+++ b/internal/provider/resource_schema_test.go
@@ -53,6 +53,7 @@ func TestAccSchemaResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "schema", NormalizedJSON(initialSchema)),
 					resource.TestCheckResourceAttr(resourceName, "schema_type", "AVRO"),
 					resource.TestCheckResourceAttr(resourceName, "compatibility_level", "NONE"),
+					resource.TestCheckResourceAttr(resourceName, "hard_delete", "false"),
 					resource.TestCheckResourceAttrSet(resourceName, "schema_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "version"),
 				),
@@ -73,6 +74,7 @@ func TestAccSchemaResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "schema", NormalizedJSON(updatedSchema)),
 					resource.TestCheckResourceAttr(resourceName, "schema_type", "AVRO"),
 					resource.TestCheckResourceAttr(resourceName, "compatibility_level", "BACKWARD"),
+					resource.TestCheckResourceAttr(resourceName, "hard_delete", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "schema_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "version"),
 				),
@@ -158,6 +160,7 @@ resource "schemaregistry_schema" "test_01" {
   subject              = "%s"
   schema_type          = "AVRO"
   compatibility_level  = "NONE"
+  hard_delete          = false
   schema               = jsonencode({
   "type": "record",
   "name": "Test",
@@ -203,6 +206,7 @@ resource "schemaregistry_schema" "test_01" {
   subject              = "%s"
   schema_type          = "AVRO"
   compatibility_level  = "BACKWARD"
+  hard_delete          = true
   schema               = jsonencode({
     "type": "record",
     "name": "TestUpdated",


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This change adds an optional `hard_delete` attribute to the `schemaregistry_schema` resource that allows users to toggle between soft and hard [deletion of schemas](https://docs.confluent.io/platform/current/schema-registry/schema-deletion-guidelines.html) by subject:

```hcl
resource "schemaregistry_schema" "example" {
  subject             = "example-subject"
  schema_type         = "AVRO"
  compatibility_level = "FORWARD_TRANSITIVE"

  hard_delete         = true      # defaults to false (soft delete)
}
```

There are a number of minor attribute changes included:

- `schema` attribute is now marked optional
- `schema_type` attribute is now required
- `compatibility_level` attribute is now computed
- Datasource attribute descriptions have been consolidated

### Relations

Closes #29 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
2024/08/13 08:45:16 🐳 Creating container for image testcontainers/ryuk:0.7.0
2024/08/13 08:45:16 ✅ Container created: 9a15ae4eceb1
2024/08/13 08:45:16 🐳 Starting container: 9a15ae4eceb1
2024/08/13 08:45:16 ✅ Container started: 9a15ae4eceb1
2024/08/13 08:45:16 ⏳ Waiting for container id 9a15ae4eceb1 image: testcontainers/ryuk:0.7.0. Waiting for: &{Port:8080/tcp timeout:<nil> PollInterval:100ms}
2024/08/13 08:45:16 🔔 Container is ready: 9a15ae4eceb1
2024/08/13 08:45:16 🐳 Creating container for image docker.redpanda.com/redpandadata/redpanda:v23.3.3
2024/08/13 08:45:16 ✅ Container created: 139110c65ff5
2024/08/13 08:45:16 🐳 Starting container: 139110c65ff5
2024/08/13 08:45:16 ✅ Container started: 139110c65ff5
2024/08/13 08:45:16 🔔 Container is ready: 139110c65ff5
=== RUN   TestAccSchemaDataSource_basic
--- PASS: TestAccSchemaDataSource_basic (1.94s)
=== RUN   TestAccSchemaDataSource_multipleVersions
--- PASS: TestAccSchemaDataSource_multipleVersions (0.95s)
=== RUN   TestAccSchemaResource_basic
=== PAUSE TestAccSchemaResource_basic
=== RUN   TestAccSchemaResource_withReferences
=== PAUSE TestAccSchemaResource_withReferences
=== CONT  TestAccSchemaResource_basic
=== CONT  TestAccSchemaResource_withReferences
--- PASS: TestAccSchemaResource_withReferences (0.94s)
--- PASS: TestAccSchemaResource_basic (0.94s)
PASS
ok      github.com/cultureamp/terraform-provider-schemaregistry/internal/provider       8.716s
...
```
