### PR TITLE
fix: optionally set compatibility type

### DIFF
--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -132,7 +132,7 @@ func (r *schemaResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 			"compatibility_level": schema.StringAttribute{
 				Description: "The compatibility level of the schema.",
 				Optional:    true,
-				Computed:    true,
+				Computed:    false,
 				Validators: []validator.String{
 					stringvalidator.OneOf(
 						"NONE",


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When the `compatibility_level attribute` is left undefined on the `schemaregistry_schema` resource, we expect it to behave as "undefined" without being assigned a default value by the provider. In other words, the provider should avoid setting the parameter entirely.

This means the `compatibility_level` attribute needs to change from `Computed: true` to `Computed: false`.

This ensures that schemas registered without an explicitly defined compatibility level will continue to use their existing "undefined" state, thereby retaining the global default compatibility level that was in effect when they were initially registered.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
2024/08/20 16:44:53 🐳 Creating container for image testcontainers/ryuk:0.7.0
2024/08/20 16:44:53 ✅ Container created: 1c109333c11f
2024/08/20 16:44:53 🐳 Starting container: 1c109333c11f
2024/08/20 16:44:53 ✅ Container started: 1c109333c11f
2024/08/20 16:44:53 ⏳ Waiting for container id 1c109333c11f image: testcontainers/ryuk:0.7.0. Waiting for: &{Port:8080/tcp timeout:<nil> PollInterval:100ms}
2024/08/20 16:44:53 🔔 Container is ready: 1c109333c11f
2024/08/20 16:44:53 🐳 Creating container for image docker.redpanda.com/redpandadata/redpanda:v23.3.3
2024/08/20 16:44:53 ✅ Container created: 9fb14bce2743
2024/08/20 16:44:53 🐳 Starting container: 9fb14bce2743
2024/08/20 16:44:53 ✅ Container started: 9fb14bce2743
2024/08/20 16:44:53 🔔 Container is ready: 9fb14bce2743
=== RUN   TestAccSchemaDataSource_basic
--- PASS: TestAccSchemaDataSource_basic (1.87s)
=== RUN   TestAccSchemaDataSource_multipleVersions
--- PASS: TestAccSchemaDataSource_multipleVersions (0.93s)
=== RUN   TestAccSchemaResource_basic
=== PAUSE TestAccSchemaResource_basic
=== RUN   TestAccSchemaResource_withReferences
=== PAUSE TestAccSchemaResource_withReferences
=== CONT  TestAccSchemaResource_basic
=== CONT  TestAccSchemaResource_withReferences
--- PASS: TestAccSchemaResource_basic (0.94s)
--- PASS: TestAccSchemaResource_withReferences (0.94s)
PASS
ok      github.com/cultureamp/terraform-provider-schemaregistry/internal/provider 
...
```
