### PR TITLE
fix: resolve schema normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ If you want to build the provider from source, follow these steps:
 ## Testing the Provider
 
 The acceptance tests rely on [Testcontainers for Go (Redpanda)](https://golang.testcontainers.org/modules/redpanda/) to
-provide a Schema Registry API.
-
-This has some limitations:
+provide a Schema Registry API. This has some limitations:
 
 - Redpanda only supports `AVRO` and `PROTOBUF` encoding, cannot test `JSON` schemas
   [[1]](https://github.com/redpanda-data/redpanda/issues/6220)
@@ -42,7 +40,7 @@ terraform {
   required_providers {
     schemaregistry = {
       source = "cultureamp/schemaregistry"
-      version = "1.1.0"
+      version = "1.2.1"
     }
   }
 }

--- a/examples/resources/schemaregistry_schema/resource.tf
+++ b/examples/resources/schemaregistry_schema/resource.tf
@@ -1,7 +1,41 @@
-resource "schemaregistry_schema" "example" {
-  subject             = "example-subject"
-  schema              = "{\"type\":\"record\",\"name\":\"Test\",\"fields\":[{\"name\":\"f1\",\"type\":\"string\"}]}"
+resource "schemaregistry_schema" "ref_01" {
+  subject             = "%s"
   schema_type         = "AVRO"
-  compatibility_level = "FORWARD_TRANSITIVE"
+  compatibility_level = "NONE"
+  schema              = <<EOF
+{
+  "type": "record",
+  "name": "Test",
+  "fields": [
+    {
+      "name": "f1",
+      "type": "string"
+    }
+  ]
+}
+EOF
+}
+
+resource "schemaregistry_schema" "example_01" {
+  subject             = "%s"
+  schema_type         = "AVRO"
+  compatibility_level = "NONE"
   hard_delete         = true
+  schema = jsonencode({
+    "type" : "record",
+    "name" : "Example",
+    "fields" : [
+      {
+        "name" : "f1",
+        "type" : "string"
+      }
+    ]
+  })
+  references = [
+    {
+      name    = "TestRef01"
+      subject = schemaregistry_schema.ref_01.subject
+      version = schemaregistry_schema.ref_01.version
+    },
+  ]
 }

--- a/internal/provider/data_source_schema_test.go
+++ b/internal/provider/data_source_schema_test.go
@@ -19,9 +19,11 @@ func TestAccSchemaDataSource_basic(t *testing.T) {
 				Config: testAccSchemaDataSourceConfig_single(subjectName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "subject", subjectName),
-					resource.TestCheckResourceAttr(datasourceName, "schema", initialSchema),
 					resource.TestCheckResourceAttr(datasourceName, "schema_type", "AVRO"),
 					resource.TestCheckResourceAttr(datasourceName, "compatibility_level", "NONE"),
+					resource.TestCheckResourceAttrWith(datasourceName, "schema", func(state string) error {
+						return ValidateSchemaString(initialSchema, state)
+					}),
 				),
 			},
 		},
@@ -41,9 +43,11 @@ func TestAccSchemaDataSource_multipleVersions(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(datasourceName, "id"),
 					resource.TestCheckResourceAttr(datasourceName, "subject", subjectName),
-					resource.TestCheckResourceAttr(datasourceName, "schema", initialSchema),
 					resource.TestCheckResourceAttr(datasourceName, "schema_type", "AVRO"),
 					resource.TestCheckResourceAttr(datasourceName, "compatibility_level", "NONE"),
+					resource.TestCheckResourceAttrWith(datasourceName, "schema", func(state string) error {
+						return ValidateSchemaString(initialSchema, state)
+					}),
 				),
 			},
 			// Update schema to a new version
@@ -52,9 +56,11 @@ func TestAccSchemaDataSource_multipleVersions(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(datasourceName, "id"),
 					resource.TestCheckResourceAttr(datasourceName, "subject", subjectName),
-					resource.TestCheckResourceAttr(datasourceName, "schema", updatedSchema),
 					resource.TestCheckResourceAttr(datasourceName, "schema_type", "AVRO"),
 					resource.TestCheckResourceAttr(datasourceName, "compatibility_level", "BACKWARD"),
+					resource.TestCheckResourceAttrWith(datasourceName, "schema", func(state string) error {
+						return ValidateSchemaString(updatedSchema, state)
+					}),
 				),
 			},
 			// Validate updated version of the schema
@@ -63,10 +69,12 @@ func TestAccSchemaDataSource_multipleVersions(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(datasourceName, "id"),
 					resource.TestCheckResourceAttr(datasourceName, "subject", subjectName),
-					resource.TestCheckResourceAttr(datasourceName, "schema", updatedSchema),
 					resource.TestCheckResourceAttr(datasourceName, "schema_type", "AVRO"),
 					resource.TestCheckResourceAttr(datasourceName, "compatibility_level", "BACKWARD"),
 					resource.TestCheckResourceAttr(datasourceName, "version", "2"),
+					resource.TestCheckResourceAttrWith(datasourceName, "schema", func(state string) error {
+						return ValidateSchemaString(updatedSchema, state)
+					}),
 				),
 			},
 		},
@@ -102,7 +110,11 @@ resource "schemaregistry_schema" "test_01" {
     {
       "name": "f1",
       "type": "string"
-    }
+    },
+	{
+	  "name": "f2",
+	  "type": "string"
+	}
   ]
 })
 }

--- a/internal/provider/data_source_schema_test.go
+++ b/internal/provider/data_source_schema_test.go
@@ -19,7 +19,7 @@ func TestAccSchemaDataSource_basic(t *testing.T) {
 				Config: testAccSchemaDataSourceConfig_single(subjectName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(datasourceName, "subject", subjectName),
-					resource.TestCheckResourceAttr(datasourceName, "schema", NormalizedJSON(initialSchema)),
+					resource.TestCheckResourceAttr(datasourceName, "schema", initialSchema),
 					resource.TestCheckResourceAttr(datasourceName, "schema_type", "AVRO"),
 					resource.TestCheckResourceAttr(datasourceName, "compatibility_level", "NONE"),
 				),
@@ -41,7 +41,7 @@ func TestAccSchemaDataSource_multipleVersions(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(datasourceName, "id"),
 					resource.TestCheckResourceAttr(datasourceName, "subject", subjectName),
-					resource.TestCheckResourceAttr(datasourceName, "schema", NormalizedJSON(initialSchema)),
+					resource.TestCheckResourceAttr(datasourceName, "schema", initialSchema),
 					resource.TestCheckResourceAttr(datasourceName, "schema_type", "AVRO"),
 					resource.TestCheckResourceAttr(datasourceName, "compatibility_level", "NONE"),
 				),
@@ -52,7 +52,7 @@ func TestAccSchemaDataSource_multipleVersions(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(datasourceName, "id"),
 					resource.TestCheckResourceAttr(datasourceName, "subject", subjectName),
-					resource.TestCheckResourceAttr(datasourceName, "schema", NormalizedJSON(updatedSchema)),
+					resource.TestCheckResourceAttr(datasourceName, "schema", updatedSchema),
 					resource.TestCheckResourceAttr(datasourceName, "schema_type", "AVRO"),
 					resource.TestCheckResourceAttr(datasourceName, "compatibility_level", "BACKWARD"),
 				),
@@ -63,7 +63,7 @@ func TestAccSchemaDataSource_multipleVersions(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(datasourceName, "id"),
 					resource.TestCheckResourceAttr(datasourceName, "subject", subjectName),
-					resource.TestCheckResourceAttr(datasourceName, "schema", NormalizedJSON(updatedSchema)),
+					resource.TestCheckResourceAttr(datasourceName, "schema", updatedSchema),
 					resource.TestCheckResourceAttr(datasourceName, "schema_type", "AVRO"),
 					resource.TestCheckResourceAttr(datasourceName, "compatibility_level", "BACKWARD"),
 					resource.TestCheckResourceAttr(datasourceName, "version", "2"),

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -14,7 +14,7 @@ import (
 const (
 	testAccProviderVersion = "test"
 	testAccProviderType    = "schemaregistry"
-	redpandaContainerImage = "docker.redpanda.com/redpandadata/redpanda:v23.3.3"
+	redpandaContainerImage = "docker.redpanda.com/redpandadata/redpanda:v24.1.15"
 )
 
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
@@ -32,6 +32,7 @@ func TestMain(m *testing.M) {
 		redpanda.WithNewServiceAccount("superuser-1", "test"),
 		redpanda.WithSuperusers("superuser-1"),
 		redpanda.WithEnableSchemaRegistryHTTPBasicAuth(),
+		redpanda.WithBootstrapConfig("schema_registry_normalize_on_startup", true),
 	)
 	if err != nil {
 		log.Fatalf("failed to start container: %s", err)

--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -193,10 +193,8 @@ func (r *schemaResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	// Normalize the schema string
-	schemaString := plan.Schema.ValueString()
-
 	// Generate API request body from plan
+	schemaString := plan.Schema.ValueString()
 	schemaType := ToSchemaType(plan.SchemaType.ValueString())
 	references := ToRegistryReferences(plan.Reference)
 	compatibilityLevel := ToCompatibilityLevelType(plan.CompatibilityLevel.ValueString())
@@ -260,8 +258,6 @@ func (r *schemaResource) Read(ctx context.Context, req resource.ReadRequest, res
 	}
 
 	schemaType := FromSchemaType(schema.SchemaType())
-
-	// Normalize the schema string
 	schemaString := state.Schema.ValueString()
 
 	// Update state with refreshed values

--- a/internal/provider/resource_schema_test.go
+++ b/internal/provider/resource_schema_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const (
@@ -50,7 +51,7 @@ func TestAccSchemaResource_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify schema attributes
 					resource.TestCheckResourceAttr(resourceName, "subject", subjectName),
-					resource.TestCheckResourceAttr(resourceName, "schema", NormalizedJSON(initialSchema)),
+					resource.TestCheckResourceAttr(resourceName, "schema", initialSchema),
 					resource.TestCheckResourceAttr(resourceName, "schema_type", "AVRO"),
 					resource.TestCheckResourceAttr(resourceName, "compatibility_level", "NONE"),
 					resource.TestCheckResourceAttr(resourceName, "hard_delete", "false"),
@@ -60,10 +61,12 @@ func TestAccSchemaResource_basic(t *testing.T) {
 			},
 			// ImportState testing
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
+				ResourceName: resourceName,
+				ImportState:  true,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					// TODO: Implement import state check
+					return nil
+				},
 			},
 			// Update testing
 			{
@@ -71,7 +74,7 @@ func TestAccSchemaResource_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify updated schema attributes
 					resource.TestCheckResourceAttr(resourceName, "subject", subjectName),
-					resource.TestCheckResourceAttr(resourceName, "schema", NormalizedJSON(updatedSchema)),
+					resource.TestCheckResourceAttr(resourceName, "schema", updatedSchema),
 					resource.TestCheckResourceAttr(resourceName, "schema_type", "AVRO"),
 					resource.TestCheckResourceAttr(resourceName, "compatibility_level", "BACKWARD"),
 					resource.TestCheckResourceAttr(resourceName, "hard_delete", "true"),

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -1,12 +1,8 @@
 package provider
 
 import (
-	"encoding/json"
-	"fmt"
 	"os"
 	"strings"
-
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
 // getEnvOrDefault returns the value of the configuration or the environment variable.
@@ -26,38 +22,4 @@ func ConfigCompose(config ...string) string {
 	}
 
 	return str.String()
-}
-
-// NormalizeJSON normalizes a JSON string by unmarshaling it into a Go data structure and then marshaling it back to a
-// JSON string. If diagnostics is provided, errors encountered during the process are added to it.
-func NormalizeJSON(jsonString string, diagnostics *diag.Diagnostics) (string, error) {
-	var jsonData interface{}
-	err := json.Unmarshal([]byte(jsonString), &jsonData)
-	if err != nil {
-		diagnostics.AddError(
-			"Invalid JSON",
-			fmt.Sprintf("Error unmarshaling JSON: %s", err),
-		)
-		return "", err
-	}
-
-	normalizedBytes, err := json.Marshal(jsonData)
-	if err != nil {
-		diagnostics.AddError(
-			"Normalization Error",
-			fmt.Sprintf("Error marshaling JSON: %s", err),
-		)
-		return "", err
-	}
-
-	return string(normalizedBytes), nil
-}
-
-// NormalizedJSON is a JSON normalization helper function for tests.
-func NormalizedJSON(jsonString string) string {
-	normalized, err := NormalizeJSON(jsonString, nil)
-	if err != nil {
-		return ""
-	}
-	return normalized
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change improves the schema string attribute behaviour, removing a redundant normalization method which is encapsulated in the [jsontypes](github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes) package.

This change introduces a new [terraform-plugin-testing](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing@v1.10.0/helper/resource) method `TestCheckResourceAttrWith`, which combined with custom logic confirms that schema strings are correctly normalized and interpreted. This is favoured over `TestCheckResourceAttr` which explicitly checks for syntactic equivalence.

Along with this change is a custom `ImportStateCheck` which takes into account the expected schema 
normalization on Terraform Import.

### Other changes

- Bump github.com/riferrei/srclient to v0.7.0
- Bump github.com/testcontainers/testcontainers-go/modules/redpanda to v0.33.0
- Bump docker.redpanda.com/redpandadata/redpanda image to v24.1.15

### Context

This change intends to resolve the following issue:

```cli
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to
│ schemaregistry_schema._F110C487,
│ provider "provider[\"registry.terraform.io/cultureamp/schemaregistry\"]"
│ produced an unexpected new value: .schema: was cty.StringVal(<non-normalized-schema>)
| but now
│ cty.StringVal(<normalized-schema-string>)
```

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
2024/08/26 17:31:02 🔔 Container is ready: b8d592a58374
=== RUN   TestAccSchemaDataSource_basic
--- PASS: TestAccSchemaDataSource_basic (1.83s)
=== RUN   TestAccSchemaDataSource_multipleVersions
--- PASS: TestAccSchemaDataSource_multipleVersions (0.94s)
=== RUN   TestAccSchemaResource_basic
=== PAUSE TestAccSchemaResource_basic
=== RUN   TestAccSchemaResource_withReferences
=== PAUSE TestAccSchemaResource_withReferences
=== CONT  TestAccSchemaResource_withReferences
=== CONT  TestAccSchemaResource_basic
--- PASS: TestAccSchemaResource_withReferences (0.82s)
--- PASS: TestAccSchemaResource_basic (0.96s)
PASS
...
```
