### PR TITLE
fix: handle undefined subject compatibility levels

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,8 +4,6 @@ run-name: Generate Changelog ${{ github.sha }} by @${{ github.actor }}
 on:
   workflow_dispatch:
   release:
-    types:
-      - published
 
 permissions:
   contents: write # to be able to commit changes

--- a/internal/provider/data_source_schema_test.go
+++ b/internal/provider/data_source_schema_test.go
@@ -110,11 +110,7 @@ resource "schemaregistry_schema" "test_01" {
     {
       "name": "f1",
       "type": "string"
-    },
-	{
-	  "name": "f2",
-	  "type": "string"
-	}
+    }
   ]
 })
 }
@@ -149,6 +145,7 @@ resource "schemaregistry_schema" "test_01" {
       {
         name = "f2",
         type = "int"
+		default = 0
       }
     ]
   })
@@ -183,6 +180,7 @@ resource "schemaregistry_schema" "test_01" {
       {
         name = "f2",
         type = "int"
+		default = 0
       }
     ]
   })

--- a/internal/provider/resource_schema_test.go
+++ b/internal/provider/resource_schema_test.go
@@ -17,10 +17,6 @@ const (
         {
             "name": "f1",
             "type": "string"
-        },
-        {
-            "name": "f2",
-            "type": "string"
         }
     ]
 }`
@@ -33,14 +29,15 @@ const (
             "name": "f1",
             "type": "string"
         },
-        {
-            "name": "f2",
-            "type": "int"
-        }
+		{
+			"name": "f2",
+			"type": "int",
+			"default": 0
+		}
     ]
 }`
 
-	expectedSchema = `{"type":"record","name":"TestUpdated","fields":[{"name":"f1","type":"string"},{"name":"f2","type":"int"}]}`
+	expectedSchema = `{"type":"record","name":"TestUpdated","fields":[{"name":"f1","type":"string"},{"name":"f2","type":"int","default":0}]}`
 )
 
 func TestAccSchemaResource_basic(t *testing.T) {
@@ -129,7 +126,7 @@ func TestAccSchemaResource_withReferences(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify updated references attributes
 					resource.TestCheckResourceAttr(resourceName, "references.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "references.0.name", "TestRefUpdated"),
+					resource.TestCheckResourceAttr(resourceName, "references.0.name", "TestRef01"),
 					resource.TestCheckResourceAttr(resourceName, "references.0.subject", ref01),
 					resource.TestCheckResourceAttr(resourceName, "references.0.version", "2"),
 				),
@@ -158,11 +155,10 @@ func testAccSchemaResourceConfig_single(subject, ref01 string) string {
 resource "schemaregistry_schema" "ref_01" {
   subject              = "%s"
   schema_type          = "AVRO"
-  compatibility_level  = "NONE"
   schema               = <<EOF
 {
   "type": "record",
-  "name": "Test",
+  "name": "TestRef01",
   "fields": [
     {
       "name": "f1",
@@ -185,11 +181,7 @@ resource "schemaregistry_schema" "test_01" {
     {
       "name": "f1",
       "type": "string"
-    },
-	{
-	  "name": "f2",
-	  "type": "string"
-	}
+    }
   ]
 })
 references = [
@@ -210,14 +202,18 @@ func testAccSchemaResourceConfig_singleUpdate(subject, ref01 string) string {
 resource "schemaregistry_schema" "ref_01" {
   subject              = "%s"
   schema_type          = "AVRO"
-  compatibility_level  = "NONE"
   schema               = jsonencode({
     "type": "record",
-    "name": "TestRefUpdated",
+    "name": "TestRef01",
     "fields": [
       {
         "name": "f1",
         "type": "string"
+      },
+      {
+        "name": "f2",
+        "type": "int"
+		"default": 0
       }
     ]
   })
@@ -238,13 +234,14 @@ resource "schemaregistry_schema" "test_01" {
       },
       {
         "name": "f2",
-        "type": "int"
-      }
+        "type": "int",
+		"default": 0
+      },
     ]
   })
   references = [
     {
-      name    = "TestRefUpdated"
+      name    = "TestRef01"
       subject = schemaregistry_schema.ref_01.subject
       version = 2
     }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes an issue encountered when `compatibility_level` is undefined and subsequently updated.

This change allows for `compatibility_level` to now be undefined and work as expected, by conditionally fetching the global compatibility level from the Schema Registry endpoint in the Create, Read and Update methods. Tests have also been updated to reflect this change.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:


--->

Closes #42 
### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
2024/09/05 09:38:34 🔔 Container is ready: aef1f4f554d4
=== RUN   TestAccSchemaDataSource_basic
--- PASS: TestAccSchemaDataSource_basic (1.88s)
=== RUN   TestAccSchemaDataSource_multipleVersions
--- PASS: TestAccSchemaDataSource_multipleVersions (0.99s)
=== RUN   TestAccSchemaResource_basic
=== PAUSE TestAccSchemaResource_basic
=== RUN   TestAccSchemaResource_withReferences
=== PAUSE TestAccSchemaResource_withReferences
=== CONT  TestAccSchemaResource_basic
=== CONT  TestAccSchemaResource_withReferences
--- PASS: TestAccSchemaResource_withReferences (0.86s)
--- PASS: TestAccSchemaResource_basic (1.01s)

...
```
