### PR TITLE
ci: implement additional workflow checks

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,15 +6,15 @@ on:
   workflow_run:
     workflows: [Release]
     types: [completed]
-
-permissions:
-  contents: write # to be able to commit changes
-  pull-requests: write # to be able to create pull requests
+    branches: [main]
 
 jobs:
   changelog:
     name: Generate Changelog
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to be able to commit changes
+      pull-requests: write # to be able to create pull requests
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -3,6 +3,7 @@ name: Tests
 run-name: Provider Tests ${{ github.sha }} by @${{ github.actor }}
 
 on:
+  merge_group:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:

--- a/.github/workflows/ci-pr-title.yml
+++ b/.github/workflows/ci-pr-title.yml
@@ -2,12 +2,9 @@ name: Validate PR Title
 run-name: Validate PR Title ${{ github.sha }} by @${{ github.actor }}
 
 on:
+  merge_group:
   pull_request:
-    types:
-      - opened
-      - edited
-      - synchronize
-      - reopened
+    types: [opened, edited, synchronize, reopened]
 
 permissions:
   pull-requests: read

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,29 @@
+name: Markdown Lint
+run-name: Markdown Lint ${{ github.sha }} by @${{ github.actor }}
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "**/*.md"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45.0.2
+        id: changed-files
+        with:
+          files: "**/*.md"
+          separator: ","
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@db43aef879112c3119a410d69f66701e0d530809 # v17.0.0
+        if: steps.changed-files.outputs.any_changed == 'true'
+        with:
+          globs: ${{ steps.changed-files.outputs.all_changed_files }}
+          separator: ","

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,15 +14,14 @@ on:
       - ".github/workflows/release.yml"
       - ".goreleaser.yml"
 
-permissions:
-  contents: write # to be able to publish a GitHub release
-  issues: write # to be able to comment on released issues
-  pull-requests: write # to be able to comment on released pull requests
-
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,6 @@ on:
       - main
     paths:
       - "**/**.go"
-      - "go.mod"
-      - "go.sum"
       - ".github/workflows/release.yml"
       - ".goreleaser.yml"
 

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,0 +1,20 @@
+name: Secrets Detection
+run-name: Secrets Detection ${{ github.sha }} by @${{ github.actor }}
+
+on:
+  merge_group:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+      - name: Secret Scanning
+        uses: trufflesecurity/trufflehog@7e78ca385fb82c19568c7a4b341c97d57d9aa5e1 # v3.82.2
+        with:
+          extra_args: --only-verified

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,3 +1,4 @@
 # Disable some built-in rules
 config:
   no-duplicate-heading: false # MD024
+  line-length: false # MD013

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,3 @@
+# Disable some built-in rules
+config:
+  no-duplicate-heading: false # MD024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-<!-- markdownlint-disable MD024 -->
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@
 
 # Terraform Provider for Schema Registry
 
+ <p align="center">
+    <a href="https://goreportcard.com/report/github.com/cultureamp/terraform-provider-schemaregistry">
+      <img src="https://goreportcard.com/badge/github.com/cultureamp/terraform-provider-schemaregistry" alt="Go report badge">
+    </a>
+    <a href="https://github.com/cultureamp/terraform-provider-schemaregistry/releases/latest">
+      <img src="https://img.shields.io/github/release/cultureamp/terraform-provider-schemaregistry.svg" alt="Release badge">
+    </a>
+</p>
+
 This provider is built using the [Terraform Plugin Framework](https://github.com/hashicorp/terraform-plugin-framework).
 
 ## Requirements
@@ -40,7 +49,7 @@ terraform {
   required_providers {
     schemaregistry = {
       source = "cultureamp/schemaregistry"
-      version = "1.2.1"
+      version = "1.2.2"
     }
   }
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

- ~Implement merge queues~ - not compatible with Semantic PR
- Add secrets detection (Trufflehog) workflow
- Add Markdown lint workflow / config for ignoring rules
- Add README badges for Go report card and releases
- Reduce scope of token permissions in workflows
- Remove `go.mod` and `go.sum` from release workflow paths trigger, as we aren't releasing new versions on patch or minor dependency updates