### PR TITLE
chore: address golangci linting issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,34 +12,34 @@ issues:
 linters:
   disable-all: true
   enable:
-    - cyclop          # Checks if the cyclic complexity of a function is acceptable
-    - dogsled         # Checks assignments with too many blank identifiers (e.g. x, , , _, := f())
+    - cyclop # Checks if the cyclic complexity of a function is acceptable
+    - dogsled # Checks assignments with too many blank identifiers (e.g. x, , , _, := f())
     - durationcheck
-    - dupl            # Detects code duplication
+    - dupl # Detects code duplication
     - errcheck
-    - exportloopref
-    - forcetypeassert 
-    - funlen          # Detects long functions
-    - gocritic        # Provides diagnostics that check for bugs, performance and style issues
+    - copyloopvar # Ensures loop variables are not reassigned on each iteration
+    - forcetypeassert
+    - funlen # Detects long functions
+    - gocritic # Provides diagnostics that check for bugs, performance and style issues
     - godot
-    - gofmt           # Checks whether code was gofmt-ed
-    - gosec           # Inspects source code for security problems
+    - gofmt # Checks whether code was gofmt-ed
+    - gosec # Inspects source code for security problems
     - gosimple
     - govet
     - ineffassign
     - makezero
-    - misspell        # Finds commonly misspelled English words in comments
-    - nestif          # Reports deeply nested if statements
-    - nilerr          # Finds the code that returns nil even if it checks that the error is not nil
+    - misspell # Finds commonly misspelled English words in comments
+    - nestif # Reports deeply nested if statements
+    - nilerr # Finds the code that returns nil even if it checks that the error is not nil
     - predeclared
     - staticcheck
     - tenv
-    - unconvert       # Remove unnecessary type conversions
-    - unparam         # Reports unused function parameters
+    - unconvert # Remove unnecessary type conversions
+    - unparam # Reports unused function parameters
     - unused
-    - whitespace      # Detects leading and trailing whitespace
+    - whitespace # Detects leading and trailing whitespace
 
 linters-settings:
   funlen:
     lines: 100
-    statements: 50    
+    statements: 50

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,12 @@ build: ## Build the provider for the current architecture
 testacc: ## Run acceptance tests
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 10m
 
+.PHONY: lint
+lint: ## Run golangci-lint, go fmt and go vet
+	golangci-lint run && \
+	go vet ./... && \
+	go fmt ./... && \
+
 .PHONY: tidy
 tidy: ## Run go mod tidy
 	go mod tidy
@@ -58,6 +64,10 @@ fmt: ## Run go fmt
 .PHONY: docs
 docs: ## Generate provider documentation for the Terraform registry
 	tfplugindocs
+
+.PHONY: coverage
+coverage: ## Generate test coverage report
+	go test -coverprofile=coverage.out ./... && go tool cover -html=coverage.out
 
 # Add double hash '##' plus the help text you would like to display for "make help" against that command
 help: ### Show help for documented commands

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/cultureamp/terraform-provider-schemaregistry
 
-go 1.21.0
+go 1.22.0
+
 toolchain go1.22.5
 
 require (

--- a/internal/provider/data_source_schema.go
+++ b/internal/provider/data_source_schema.go
@@ -207,7 +207,6 @@ func (d *schemaDataSource) fetchCompatibilityLevel(subject string) (*srclient.Co
 // mapSchemaToOutputs maps the schema and compatibility level to the schema data source model.
 func (d *schemaDataSource) mapSchemaToOutputs(subject string, schema *srclient.Schema,
 	compatibilityLevel *srclient.CompatibilityLevel) schemaDataSourceModel {
-
 	return schemaDataSourceModel{
 		ID:                 types.StringValue(subject),
 		Subject:            types.StringValue(subject),

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -52,11 +52,9 @@ func TestMain(m *testing.M) {
 	tests := m.Run()
 
 	// Clean up the container
-	defer func() {
-		if err := redpandaContainer.Terminate(ctx); err != nil {
-			log.Fatalf("failed to terminate container: %s", err)
-		}
-	}()
+	if err := redpandaContainer.Terminate(ctx); err != nil {
+		log.Fatalf("failed to terminate container: %s", err)
+	}
 
 	os.Exit(tests)
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Addresses the following golangci linting issues:

1. Gocritic
```
Build: internal/provider/provider_test.go#L61exitAfterDefer: os.Exit will exit, and `defer func(){...}(...)` will not run (gocritic)
```
2. Gocritic
```
Build: internal/provider/data_source_schema.go#L209unnecessary leading newline (whitespace)
```
3. exportloopref
```
  level=warning msg="The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar."
```

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc
2024/10/28 13:22:08 🔔 Container is ready: e1e4145ec85b
2024/10/28 13:22:08 🐳 Creating container for image docker.redpanda.com/redpandadata/redpanda:v24.1.15
2024/10/28 13:22:08 ✅ Container created: e2b6ecda6dc1
2024/10/28 13:22:08 🐳 Starting container: e2b6ecda6dc1
2024/10/28 13:22:08 ✅ Container started: e2b6ecda6dc1
2024/10/28 13:22:08 ⏳ Waiting for container id e2b6ecda6dc1 image: docker.redpanda.com/redpandadata/redpanda:v24.1.15. Waiting for: &{timeout:<nil> deadline:<nil> Strategies:[0x14000401830 0x14000401860 0x14000401890]}
2024/10/28 13:22:08 🔔 Container is ready: e2b6ecda6dc1
=== RUN   TestAccSchemaDataSource_basic
--- PASS: TestAccSchemaDataSource_basic (3.88s)
=== RUN   TestAccSchemaDataSource_multipleVersions
--- PASS: TestAccSchemaDataSource_multipleVersions (0.99s)
=== RUN   TestAccSchemaResource_basic
=== PAUSE TestAccSchemaResource_basic
=== RUN   TestAccSchemaResource_withReferences
=== PAUSE TestAccSchemaResource_withReferences
=== CONT  TestAccSchemaResource_basic
=== CONT  TestAccSchemaResource_withReferences
--- PASS: TestAccSchemaResource_withReferences (0.79s)
--- PASS: TestAccSchemaResource_basic (0.91s)
PASS
2024/10/28 13:22:15 🐳 Terminating container: e2b6ecda6dc1
...
```
