### PR TITLE
ci: re-enable markdownlint workflow with changed-files bump

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,6 +1,9 @@
 name: Markdown Lint
 run-name: Markdown Lint ${{ github.sha }} by @${{ github.actor }}
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,29 +1,29 @@
-# name: Markdown Lint
-# run-name: Markdown Lint ${{ github.sha }} by @${{ github.actor }}
+name: Markdown Lint
+run-name: Markdown Lint ${{ github.sha }} by @${{ github.actor }}
 
-# on:
-#   pull_request:
-#     types: [opened, synchronize, reopened]
-#     paths:
-#       - "**/*.md"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "**/*.md"
 
-# jobs:
-#   lint:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Checkout code
-#         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-#         with:
-#           fetch-depth: 0
-#       - name: Get changed files
-#         uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45.0.2
-#         id: changed-files
-#         with:
-#           files: "**/*.md"
-#           separator: ","
-#       - name: Run markdownlint
-#         uses: DavidAnson/markdownlint-cli2-action@db43aef879112c3119a410d69f66701e0d530809 # v17.0.0
-#         if: steps.changed-files.outputs.any_changed == 'true'
-#         with:
-#           globs: ${{ steps.changed-files.outputs.all_changed_files }}
-#           separator: ","
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
+        id: changed-files
+        with:
+          files: "**/*.md"
+          separator: ","
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@db43aef879112c3119a410d69f66701e0d530809 # v17.0.0
+        if: steps.changed-files.outputs.any_changed == 'true'
+        with:
+          globs: ${{ steps.changed-files.outputs.all_changed_files }}
+          separator: ","


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Re-enable markdownlint workflow and pin to latest version of tj-actions/changed-files: https://github.com/tj-actions/changed-files/releases
### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
