### PR TITLE
ci: update PR title validation workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,4 +1,5 @@
-name: Generate Changelog
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+---
 run-name: Generate Changelog ${{ github.sha }} by @${{ github.actor }}
 
 on:

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+---
 # Terraform Provider testing workflow.
 name: Tests
 run-name: Provider Tests ${{ github.sha }} by @${{ github.actor }}

--- a/.github/workflows/ci-pr-title.yml
+++ b/.github/workflows/ci-pr-title.yml
@@ -1,19 +1,48 @@
-name: Validate PR Title
-run-name: Validate PR Title ${{ github.sha }} by @${{ github.actor }}
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+---
+# see: https://github.com/cultureamp/terraform-provider-schemaregistry/blob/main/.github/workflows/ci-pr-title.yml
+# see: https://www.conventionalcommits.org
+name: Semantic PR Title
+run-name: Semantic PR Title ${{ github.sha }} by @${{ github.actor }}
 
 on:
-  merge_group:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   main:
-    name: Semantic PR Title
+    name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+      # https://github.com/amannn/action-semantic-pull-request
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true

--- a/.github/workflows/ci-pr-title.yml
+++ b/.github/workflows/ci-pr-title.yml
@@ -1,6 +1,5 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 ---
-# see: https://github.com/cultureamp/terraform-provider-schemaregistry/blob/main/.github/workflows/ci-pr-title.yml
 # see: https://www.conventionalcommits.org
 name: Semantic PR Title
 run-name: Semantic PR Title ${{ github.sha }} by @${{ github.actor }}
@@ -18,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # https://github.com/amannn/action-semantic-pull-request
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3 - https://github.com/amannn/action-semantic-pull-request/releases/tag/v5.5.3
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2 - https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.2
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
@@ -42,7 +41,7 @@ jobs:
 
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2 - https://github.com/marocchino/sticky-pull-request-comment/releases/tag/v2.9.2
         with:
           header: pr-title-lint-error
           delete: true

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+---
 name: Markdown Lint
 run-name: Markdown Lint ${{ github.sha }} by @${{ github.actor }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+---
 # Terraform Provider release workflow.
 name: Release
 run-name: Release ${{ github.sha }} by @${{ github.actor }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+---
 name: OpenSSF Scorecard
 run-name: OpenSSF Scorecard ${{ github.sha }} by @${{ github.actor }}
 

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+---
 name: Secrets Detection
 run-name: Secrets Detection ${{ github.sha }} by @${{ github.actor }}
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for validating pull request titles to enforce the Conventional Commits specification. It includes improvements for better error handling and user feedback.

### Workflow enhancements:

* Updated the workflow name to `Semantic PR Title` and the job name to `Validate PR title` to reflect the focus on enforcing the Conventional Commits specification.
* Changed the permissions for `pull-requests` from `read` to `write` to support additional functionality.
* Updated the action `amannn/action-semantic-pull-request` to use the latest version (`v5`) for validating PR titles.
* Add the `yaml-language-server` schema to each workflow item

### Improved error handling and user feedback:

* Added the `marocchino/sticky-pull-request-comment@v2` action to provide detailed feedback when the PR title validation fails, including a message explaining the issue and referencing the Conventional Commits specification.
* Implemented logic to delete the error comment automatically when the PR title issue is resolved.
