### PR TITLE
fix: update version state and references logic

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -47,7 +47,7 @@ type ProviderModel struct {
 
 const (
 	schemaRegistryURLPattern = `^https?://.*$`
-	defaultTimeout           = 5 * time.Second
+	defaultTimeout           = 30 * time.Second
 )
 
 var schemaRegistryURLRegex = regexp.MustCompile(schemaRegistryURLPattern)

--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -11,10 +11,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/riferrei/srclient"
 )
 
@@ -83,7 +85,7 @@ func (r *schemaResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 			},
 			"schema": schema.StringAttribute{
 				Description: "The schema definition.",
-				Optional:    true,
+				Required:    true,
 				CustomType:  jsontypes.NormalizedType{},
 				Validators: []validator.String{
 					stringvalidator.LengthAtLeast(2),
@@ -114,6 +116,9 @@ func (r *schemaResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 			"references": schema.ListNestedAttribute{
 				Description: "The referenced schema list.",
 				Optional:    true,
+				PlanModifiers: []planmodifier.List{
+					listplanmodifier.UseStateForUnknown(),
+				},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{
@@ -141,6 +146,9 @@ func (r *schemaResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				Description: "The compatibility level of the schema.",
 				Optional:    true,
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				Validators: []validator.String{
 					stringvalidator.OneOf(
 						"NONE",
@@ -204,7 +212,11 @@ func (r *schemaResource) Create(ctx context.Context, req resource.CreateRequest,
 	// Generate API request body from plan
 	schemaString := plan.Schema.ValueString()
 	schemaType := utils.ToSchemaType(plan.SchemaType.ValueString())
-	references := utils.ToRegistryReferences(plan.Reference)
+	references, diags := utils.ToRegistryReferences(ctx, r.client, plan.Reference)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	// Create new schema resource
 	schema, err := r.client.CreateSchema(subject, schemaString, schemaType, references...)
@@ -248,9 +260,8 @@ func (r *schemaResource) Create(ctx context.Context, req resource.CreateRequest,
 	plan.Schema = jsontypes.NewNormalizedValue(schema.Schema())
 	plan.SchemaID = types.Int64Value(int64(schema.ID()))
 	plan.SchemaType = types.StringValue(schemaTypeStr)
-	plan.Version = types.Int64Value(1) // Set the version to 1 for new schema
+	plan.Version = types.Int64Value(int64(schema.Version()))
 	plan.Reference = utils.FromRegistryReferences(schema.References())
-	plan.HardDelete = types.BoolValue(plan.HardDelete.ValueBool())
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, plan)
@@ -323,9 +334,13 @@ func (r *schemaResource) Update(ctx context.Context, req resource.UpdateRequest,
 	// Generate API request body from plan
 	schemaString := plan.Schema.ValueString()
 	subject := plan.Subject.ValueString()
-	references := utils.ToRegistryReferences(plan.Reference)
 	schemaType := utils.ToSchemaType(plan.SchemaType.ValueString())
 	compatibilityLevel := utils.ToCompatibilityLevelType(plan.CompatibilityLevel.ValueString())
+	references, diags := utils.ToRegistryReferences(ctx, r.client, plan.Reference)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	// Update existing schema
 	schema, err := r.client.CreateSchema(subject, schemaString, schemaType, references...)
@@ -362,11 +377,11 @@ func (r *schemaResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	// Update state with refreshed values
-	plan.Schema = jsontypes.NewNormalizedValue(schemaString)
+	plan.Schema = jsontypes.NewNormalizedValue(schema.Schema())
+	plan.SchemaType = types.StringValue(utils.FromSchemaType(schema.SchemaType()))
 	plan.SchemaID = types.Int64Value(int64(schema.ID()))
 	plan.Version = types.Int64Value(int64(schema.Version()))
 	plan.Reference = utils.FromRegistryReferences(schema.References())
-	plan.HardDelete = types.BoolValue(plan.HardDelete.ValueBool())
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
@@ -385,10 +400,10 @@ func (r *schemaResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		return
 	}
 
-	deletionType := state.HardDelete.ValueBool()
+	hardDelete := state.HardDelete.ValueBool()
 
 	// Delete existing schema
-	err := r.client.DeleteSubject(state.Subject.ValueString(), deletionType)
+	err := r.client.DeleteSubject(state.Subject.ValueString(), hardDelete)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Deleting Schema",
@@ -396,6 +411,11 @@ func (r *schemaResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		)
 		return
 	}
+
+	resp.State.RemoveResource(ctx)
+
+	tflog.Info(ctx, fmt.Sprintf("Schema %s deleted (%s delete)", state.Subject.ValueString(),
+		map[bool]string{true: "hard", false: "soft"}[hardDelete]))
 }
 
 func (r *schemaResource) ImportState(ctx context.Context, req resource.ImportStateRequest,

--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -212,7 +212,7 @@ func (r *schemaResource) Create(ctx context.Context, req resource.CreateRequest,
 	// Generate API request body from plan
 	schemaString := plan.Schema.ValueString()
 	schemaType := utils.ToSchemaType(plan.SchemaType.ValueString())
-	references, diags := utils.ToRegistryReferences(ctx, r.client, plan.Reference)
+	references, diags := utils.ToRegistryReferences(ctx, plan.Reference)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -256,7 +256,7 @@ func (r *schemaResource) Create(ctx context.Context, req resource.CreateRequest,
 	schemaTypeStr := utils.FromSchemaType(schema.SchemaType())
 
 	// Map response body to schema
-	plan.ID = plan.Subject
+	plan.ID = types.StringValue(subject)
 	plan.Schema = jsontypes.NewNormalizedValue(schema.Schema())
 	plan.SchemaID = types.Int64Value(int64(schema.ID()))
 	plan.SchemaType = types.StringValue(schemaTypeStr)
@@ -336,7 +336,7 @@ func (r *schemaResource) Update(ctx context.Context, req resource.UpdateRequest,
 	subject := plan.Subject.ValueString()
 	schemaType := utils.ToSchemaType(plan.SchemaType.ValueString())
 	compatibilityLevel := utils.ToCompatibilityLevelType(plan.CompatibilityLevel.ValueString())
-	references, diags := utils.ToRegistryReferences(ctx, r.client, plan.Reference)
+	references, diags := utils.ToRegistryReferences(ctx, plan.Reference)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/resource_schema_test.go
+++ b/internal/provider/resource_schema_test.go
@@ -188,7 +188,7 @@ references = [
     {
       name    = "TestRef01"
       subject = schemaregistry_schema.ref_01.subject
-      version = 1
+      version = 1 # schemaregistry_schema.ref_01.version
     },
   ]
 }
@@ -243,7 +243,7 @@ resource "schemaregistry_schema" "test_01" {
     {
       name    = "TestRef01"
       subject = schemaregistry_schema.ref_01.subject
-      version = schemaregistry_schema.ref_01.subject
+      version = 2 # schemaregistry_schema.ref_01.version
     }
   ]
 }

--- a/internal/provider/resource_schema_test.go
+++ b/internal/provider/resource_schema_test.go
@@ -188,7 +188,7 @@ references = [
     {
       name    = "TestRef01"
       subject = schemaregistry_schema.ref_01.subject
-      version = schemaregistry_schema.ref_01.version
+      version = 1
     },
   ]
 }
@@ -212,8 +212,8 @@ resource "schemaregistry_schema" "ref_01" {
       },
       {
         "name": "f2",
-        "type": "int"
-		"default": 0
+        "type": "int",
+        "default": 0
       }
     ]
   })
@@ -243,7 +243,7 @@ resource "schemaregistry_schema" "test_01" {
     {
       name    = "TestRef01"
       subject = schemaregistry_schema.ref_01.subject
-      version = 2
+      version = schemaregistry_schema.ref_01.subject
     }
   ]
 }

--- a/internal/utils/conversions.go
+++ b/internal/utils/conversions.go
@@ -1,12 +1,20 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/riferrei/srclient"
 )
+
+type refItem struct {
+	Name    string `tfsdk:"name"`
+	Subject string `tfsdk:"subject"`
+	Version int64  `tfsdk:"version"`
+}
 
 func FromRegistryReferences(references []srclient.Reference) types.List {
 	referenceType := types.ObjectType{
@@ -46,40 +54,41 @@ func FromRegistryReferences(references []srclient.Reference) types.List {
 	return listValue
 }
 
-func ToRegistryReferences(references types.List) []srclient.Reference {
-	if references.IsNull() || references.IsUnknown() {
-		return nil
+// ToRegistryReferences turns a Terraform list of {name,subject,version} into SRclient refs.
+func ToRegistryReferences(ctx context.Context, client *srclient.SchemaRegistryClient, in types.List) ([]srclient.Reference, diag.Diagnostics) {
+	if in.IsNull() || in.IsUnknown() {
+		return nil, nil
 	}
 
-	var refs []srclient.Reference
-	for _, reference := range references.Elements() {
-		if !reference.IsNull() && !reference.IsUnknown() {
-			ref, ok := reference.(types.Object)
-			if !ok {
-				fmt.Printf("Invalid reference object type: %v\n", reference)
-				continue
+	var items []refItem
+	diags := in.ElementsAs(ctx, &items, false)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	out := make([]srclient.Reference, 0, len(items))
+	for _, it := range items {
+		vers := int(it.Version)
+
+		if vers <= 0 {
+			schema, err := client.GetLatestSchema(it.Subject)
+			if err != nil {
+				diags.AddError(
+					"Error resolving reference version",
+					fmt.Sprintf("Could not get latest schema for subject %s: %s", it.Subject, err.Error()),
+				)
+				return nil, diags
 			}
-
-			attributes := ref.Attributes()
-			nameAttr, nameOk := attributes["name"].(types.String)
-			subjectAttr, subjectOk := attributes["subject"].(types.String)
-			versionAttr, versionOk := attributes["version"].(types.Int64)
-
-			if !nameOk || !subjectOk || !versionOk {
-				// Log error and skip this reference
-				fmt.Printf("Error extracting attributes from reference object: %v\n", attributes)
-				continue
-			}
-
-			refs = append(refs, srclient.Reference{
-				Name:    nameAttr.ValueString(),
-				Subject: subjectAttr.ValueString(),
-				Version: int(versionAttr.ValueInt64()),
-			})
+			vers = schema.Version()
 		}
-	}
 
-	return refs
+		out = append(out, srclient.Reference{
+			Name:    it.Name,
+			Subject: it.Subject,
+			Version: vers,
+		})
+	}
+	return out, diags
 }
 
 func FromSchemaType(schemaType *srclient.SchemaType) string {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

- Adjust provider client timeout from 5s to 30s to accommodate retry backoffs
- Replace hard-coded default version on Create (i.e. Version = 1) with the actual returned values from the registry
- Improve references handling for correctness

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2
2025/05/27 11:54:56 🔔 Container is ready: e0662b8db11f
=== RUN   TestAccSchemaDataSource_basic
--- PASS: TestAccSchemaDataSource_basic (1.94s)
=== RUN   TestAccSchemaDataSource_multipleVersions
--- PASS: TestAccSchemaDataSource_multipleVersions (1.02s)
=== RUN   TestAccSchemaResource_basic
=== PAUSE TestAccSchemaResource_basic
=== RUN   TestAccSchemaResource_withReferences
=== PAUSE TestAccSchemaResource_withReferences
=== CONT  TestAccSchemaResource_basic
=== CONT  TestAccSchemaResource_withReferences
--- PASS: TestAccSchemaResource_withReferences (0.76s)
--- PASS: TestAccSchemaResource_basic (0.89s)
PASS
...
```
