### PR TITLE
feat: update `ModifyPlan` with semantic lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ testacc: ## Run acceptance tests
 lint: ## Run golangci-lint, go fmt and go vet
 	golangci-lint run && \
 	go vet ./... && \
-	go fmt ./... && \
+	go fmt ./...
 
 .PHONY: tidy
 tidy: ## Run go mod tidy

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/redpanda v0.37.0
 )
 
-replace github.com/riferrei/srclient => github.com/dstrates/srclient v0.0.0-20250522235454-c6bed0a51a13
+replace github.com/riferrei/srclient => github.com/dstrates/srclient v0.0.0-20250626074010-6fd8e320d4de
 
 require (
 	dario.cat/mergo v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/dstrates/srclient v0.0.0-20250522235454-c6bed0a51a13 h1:imspI4006/bLR+jPq4MUKCpKGejfRDOtz8UnvwlnnlQ=
-github.com/dstrates/srclient v0.0.0-20250522235454-c6bed0a51a13/go.mod h1:byIzLF4UNZzclmzQXXr++Oe1GEH/hNFahUOSTXc7uSc=
+github.com/dstrates/srclient v0.0.0-20250626074010-6fd8e320d4de h1:OYSKr76MccHbabDYHiruMd/Cvjgi917fhFM3ohFHKmc=
+github.com/dstrates/srclient v0.0.0-20250626074010-6fd8e320d4de/go.mod h1:byIzLF4UNZzclmzQXXr++Oe1GEH/hNFahUOSTXc7uSc=
 github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z1I=
 github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -71,3 +71,12 @@ func formatDiagnostics(diags diag.Diagnostics) error {
 
 	return errors.New(strings.Join(messages, "; "))
 }
+
+// NormalizeSchemaString removes all whitespace and newlines from a schema string
+// to create a minimal normalized version for testing purposes.
+func NormalizeSchemaString(schema string) string {
+	normalized := strings.ReplaceAll(schema, "\n", "")
+	normalized = strings.ReplaceAll(normalized, " ", "")
+	normalized = strings.ReplaceAll(normalized, "\t", "")
+	return normalized
+}

--- a/internal/utils/schema_semantic_equal.go
+++ b/internal/utils/schema_semantic_equal.go
@@ -25,15 +25,14 @@ func IsSemanticallyEqual(
 	schemaType srclient.SchemaType,
 	refs []srclient.Reference,
 ) (bool, error) {
-
 	req := &srclient.RegisterSchemaRequest{
 		Schema:     schemaString,
 		SchemaType: schemaType,
 		References: refs,
 	}
-
-	// Lookup schema with `normalize = true`
-	_, _, _, err := client.LookupSchemaUnderSubject(ctx, subject, req, true)
+	// Lookup schema with `normalize = true` We only care about the error, but
+	// need to handle all return values
+	_, _, _, err := client.LookupSchemaUnderSubject(ctx, subject, req, true) //nolint:dogsled
 
 	switch {
 	case err == nil:

--- a/internal/utils/schema_semantic_equal.go
+++ b/internal/utils/schema_semantic_equal.go
@@ -1,0 +1,47 @@
+package utils
+
+import (
+	"context"
+	"errors"
+
+	"github.com/riferrei/srclient"
+)
+
+// IsSemanticallyEqual checks if a given schema is semantically equivalent to
+// any existing schema under the specified subject in the Schema Registry.  It
+// returns true when the lookup succeeds, false when the registry replies 40403
+// (ErrSemanticSchemaNotFound), and an error for anything else.
+//
+// The function uses the Schema Registry's lookup functionality with
+// normalization enabled to determine semantic equivalence. Two schemas are
+// considered semantically equal if they have the same structure and meaning,
+// even if they differ in formatting, field ordering, or other non-semantic
+// aspects.
+func IsSemanticallyEqual(
+	ctx context.Context,
+	client *srclient.SchemaRegistryClient,
+	subject string,
+	schemaString string,
+	schemaType srclient.SchemaType,
+	refs []srclient.Reference,
+) (bool, error) {
+
+	req := &srclient.RegisterSchemaRequest{
+		Schema:     schemaString,
+		SchemaType: schemaType,
+		References: refs,
+	}
+
+	// Lookup schema with `normalize = true`
+	_, _, _, err := client.LookupSchemaUnderSubject(ctx, subject, req, true)
+
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, srclient.ErrSemanticSchemaNotFound):
+		return false, nil
+
+	default:
+		return false, err
+	}
+}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Update `ModifyPlan` to add support for schema registry semantic comparison with `IsSemanticallyEqual`.

This allows the provider to compare planned schemas to those returned by the registry _after_ canonicalization is performed (e.g. Avro), ensuring we suppress diffs for semantically equal schemas.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

Implements https://github.com/dstrates/srclient/pull/1
Relates to #102

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
=== RUN   TestAccSchemaDataSource_basic
--- PASS: TestAccSchemaDataSource_basic (2.15s)
=== RUN   TestAccSchemaDataSource_multipleVersions
--- PASS: TestAccSchemaDataSource_multipleVersions (1.39s)
=== RUN   TestAccSchemaResource_basic
=== PAUSE TestAccSchemaResource_basic
=== RUN   TestAccSchemaResource_withReferences
=== PAUSE TestAccSchemaResource_withReferences
=== RUN   TestAccSchemaResource_modifyPlan
=== PAUSE TestAccSchemaResource_modifyPlan
=== CONT  TestAccSchemaResource_basic
=== CONT  TestAccSchemaResource_modifyPlan
=== CONT  TestAccSchemaResource_withReferences
--- PASS: TestAccSchemaResource_withReferences (1.01s)
--- PASS: TestAccSchemaResource_modifyPlan (1.32s)
--- PASS: TestAccSchemaResource_basic (1.35s)
PASS
...
```
