### PR TITLE
ci: fix pipeline dependencies

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,4 +1,5 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+---
 name: Pipeline
 run-name: Pipeline ${{ github.sha }} by @${{ github.actor }}
 
@@ -15,6 +16,7 @@ jobs:
   find-changed-files:
     name: Changed Files
     runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
     outputs:
       lint_any_changed: ${{ steps.changed-files.outputs.lint_any_changed }}
       app_any_changed: ${{ steps.changed-files.outputs.app_any_changed }}
@@ -52,7 +54,7 @@ jobs:
     name: Secrets
     needs: [find-changed-files]
     if: |
-      github.ref != 'refs/heads/main' ||
+      github.ref != 'refs/heads/main' &&
       needs.find-changed-files.outputs.any_changed == 'true'
     uses: ./.github/workflows/trufflehog.yml
     secrets: inherit
@@ -72,7 +74,7 @@ jobs:
     name: Build and Test
     needs: [find-changed-files]
     if: |
-      github.ref != 'refs/heads/main' &&
+      github.ref == 'refs/heads/main' ||
       needs.find-changed-files.outputs.app_any_changed == 'true'
     uses: ./.github/workflows/ci-go.yml
     secrets: inherit
@@ -102,5 +104,5 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1
         id: check-pipeline
         with:
-          allowed-skips: "lint,app,release"
+          allowed-skips: "secrets,lint,app,release"
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fixes some pipeline step dependencies and conditions:

- Only run `changed-files` on branches since this isn't required on push to main
- Only run `secrets` on branches, we don't need to scan again after push to main
- Run `build and test` on main (release pre-requisite) or on changes to the provider

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
