### PR TITLE
ci: fix goreleaser archive formats field rename

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,7 +36,7 @@ builds:
         goarch: arm
     binary: "{{ .ProjectName }}_v{{ .Version }}"
 archives:
-  - formats: zip
+  - format: zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
   extra_files:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,7 +36,7 @@ builds:
         goarch: arm
     binary: "{{ .ProjectName }}_v{{ .Version }}"
 archives:
-  - format: zip
+  - formats: [zip]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 checksum:
   extra_files:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
GoReleaser v2 renamed formats --> format (singular) in the archives section

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

Relates to #220 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
