### PR TITLE
fix: add context to schema diagnostics

### DIFF
--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -200,7 +200,7 @@ func (r *schemaResource) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 	// Get current state
 	var state schemaResourceModel
 	diags := req.State.Get(ctx, &state)
-	resp.Diagnostics.Append(diags...)
+	utils.AppendSchemaDiagnostics(&resp.Diagnostics, diags, state.Subject, state.Version)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -208,13 +208,13 @@ func (r *schemaResource) ModifyPlan(ctx context.Context, req resource.ModifyPlan
 	// Get new plan
 	var plan schemaResourceModel
 	diags = req.Plan.Get(ctx, &plan)
-	resp.Diagnostics.Append(diags...)
+	utils.AppendSchemaDiagnostics(&resp.Diagnostics, diags, plan.Subject, plan.Version)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	references, diags := utils.ToRegistryReferences(ctx, plan.Reference)
-	resp.Diagnostics.Append(diags...)
+	utils.AppendSchemaDiagnostics(&resp.Diagnostics, diags, plan.Subject, plan.Version)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -257,7 +257,7 @@ func (r *schemaResource) Create(ctx context.Context, req resource.CreateRequest,
 	// Retrieve values from plan
 	var plan schemaResourceModel
 	diags := req.Plan.Get(ctx, &plan)
-	resp.Diagnostics.Append(diags...)
+	utils.AppendSchemaDiagnostics(&resp.Diagnostics, diags, plan.Subject, plan.Version)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -277,7 +277,7 @@ func (r *schemaResource) Create(ctx context.Context, req resource.CreateRequest,
 	schemaString := plan.Schema.ValueString()
 	schemaType := utils.ToSchemaType(plan.SchemaType.ValueString())
 	references, diags := utils.ToRegistryReferences(ctx, plan.Reference)
-	resp.Diagnostics.Append(diags...)
+	utils.AppendSchemaDiagnostics(&resp.Diagnostics, diags, plan.Subject, plan.Version)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -329,7 +329,7 @@ func (r *schemaResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, plan)
-	resp.Diagnostics.Append(diags...)
+	utils.AppendSchemaDiagnostics(&resp.Diagnostics, diags, plan.Subject, plan.Version)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -339,7 +339,7 @@ func (r *schemaResource) Read(ctx context.Context, req resource.ReadRequest, res
 	var state schemaResourceModel
 
 	diags := req.State.Get(ctx, &state)
-	resp.Diagnostics.Append(diags...)
+	utils.AppendSchemaDiagnostics(&resp.Diagnostics, diags, state.Subject, state.Version)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -397,7 +397,7 @@ func (r *schemaResource) Read(ctx context.Context, req resource.ReadRequest, res
 
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)
-	resp.Diagnostics.Append(diags...)
+	utils.AppendSchemaDiagnostics(&resp.Diagnostics, diags, state.Subject, state.Version)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -409,14 +409,14 @@ func (r *schemaResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	// Read Terraform plan data into the model
 	diags := req.Plan.Get(ctx, &plan)
-	resp.Diagnostics.Append(diags...)
+	utils.AppendSchemaDiagnostics(&resp.Diagnostics, diags, plan.Subject, plan.Version)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	// Read current state
 	diags = req.State.Get(ctx, &state)
-	resp.Diagnostics.Append(diags...)
+	utils.AppendSchemaDiagnostics(&resp.Diagnostics, diags, state.Subject, state.Version)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -424,7 +424,7 @@ func (r *schemaResource) Update(ctx context.Context, req resource.UpdateRequest,
 	// Generate API request body from plan
 	subject := plan.Subject.ValueString()
 	references, diags := utils.ToRegistryReferences(ctx, plan.Reference)
-	resp.Diagnostics.Append(diags...)
+	utils.AppendSchemaDiagnostics(&resp.Diagnostics, diags, plan.Subject, plan.Version)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -458,7 +458,7 @@ func (r *schemaResource) Update(ctx context.Context, req resource.UpdateRequest,
 	plan.CompatibilityLevel = types.StringValue(compatibilityLevel)
 
 	diags = resp.State.Set(ctx, plan)
-	resp.Diagnostics.Append(diags...)
+	utils.AppendSchemaDiagnostics(&resp.Diagnostics, diags, plan.Subject, plan.Version)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -535,7 +535,7 @@ func (r *schemaResource) Delete(ctx context.Context, req resource.DeleteRequest,
 
 	// Get current state
 	diags := req.State.Get(ctx, &state)
-	resp.Diagnostics.Append(diags...)
+	utils.AppendSchemaDiagnostics(&resp.Diagnostics, diags, state.Subject, state.Version)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -615,7 +615,7 @@ func (r *schemaResource) ImportState(ctx context.Context, req resource.ImportSta
 
 	// Set the state
 	diags := resp.State.Set(ctx, state)
-	resp.Diagnostics.Append(diags...)
+	utils.AppendSchemaDiagnostics(&resp.Diagnostics, diags, state.Subject, state.Version)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/utils/diagnostics.go
+++ b/internal/utils/diagnostics.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// AppendSchemaDiagnostics adds known schema context to error diagnostics while
+// preserving warnings and attribute paths.
+func AppendSchemaDiagnostics(
+	target *diag.Diagnostics,
+	diagnostics diag.Diagnostics,
+	subject types.String,
+	version types.Int64,
+) {
+	contextParts := make([]string, 0, 2)
+	if !subject.IsNull() && !subject.IsUnknown() {
+		contextParts = append(contextParts, fmt.Sprintf("subject %q", subject.ValueString()))
+	}
+	if !version.IsNull() && !version.IsUnknown() {
+		contextParts = append(contextParts, fmt.Sprintf("version %d", version.ValueInt64()))
+	}
+
+	if len(contextParts) == 0 {
+		target.Append(diagnostics...)
+		return
+	}
+
+	contextDetail := strings.Join(contextParts, ", ")
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Severity() != diag.SeverityError {
+			target.Append(diagnostic)
+			continue
+		}
+
+		detail := fmt.Sprintf("%s\n\nSchema context: %s.", diagnostic.Detail(), contextDetail)
+		if diagnosticWithPath, ok := diagnostic.(diag.DiagnosticWithPath); ok {
+			target.Append(diag.NewAttributeErrorDiagnostic(
+				diagnosticWithPath.Path(),
+				diagnostic.Summary(),
+				detail,
+			))
+			continue
+		}
+
+		target.Append(diag.NewErrorDiagnostic(diagnostic.Summary(), detail))
+	}
+}

--- a/internal/utils/diagnostics_test.go
+++ b/internal/utils/diagnostics_test.go
@@ -1,0 +1,97 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestAppendSchemaDiagnosticsAddsKnownContext(t *testing.T) {
+	t.Parallel()
+
+	diagnosticPath := path.Root("references").AtListIndex(0).AtName("version")
+	errorDiagnostic := diag.NewAttributeErrorDiagnostic(
+		diagnosticPath,
+		"Invalid reference",
+		"Reference version could not be decoded.",
+	)
+	warningDiagnostic := diag.NewWarningDiagnostic(
+		"Deprecated field",
+		"This warning should remain unchanged.",
+	)
+
+	var got diag.Diagnostics
+	AppendSchemaDiagnostics(
+		&got,
+		diag.Diagnostics{errorDiagnostic, warningDiagnostic},
+		types.StringValue("orders-value"),
+		types.Int64Value(7),
+	)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 diagnostics, got %d", len(got))
+	}
+
+	const wantDetail = "Reference version could not be decoded.\n\nSchema context: subject \"orders-value\", version 7."
+	if got[0].Detail() != wantDetail {
+		t.Errorf("unexpected error detail:\nwant: %q\n got: %q", wantDetail, got[0].Detail())
+	}
+
+	gotWithPath, ok := got[0].(diag.DiagnosticWithPath)
+	if !ok {
+		t.Fatal("expected error diagnostic to retain its attribute path")
+	}
+	if !gotWithPath.Path().Equal(diagnosticPath) {
+		t.Errorf("unexpected diagnostic path: %s", gotWithPath.Path())
+	}
+
+	if !got[1].Equal(warningDiagnostic) {
+		t.Error("expected warning diagnostic to remain unchanged")
+	}
+}
+
+func TestAppendSchemaDiagnosticsOmitsUnknownContext(t *testing.T) {
+	t.Parallel()
+
+	errorDiagnostic := diag.NewErrorDiagnostic("Invalid plan", "Plan could not be decoded.")
+
+	var got diag.Diagnostics
+	AppendSchemaDiagnostics(
+		&got,
+		diag.Diagnostics{errorDiagnostic},
+		types.StringUnknown(),
+		types.Int64Null(),
+	)
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", len(got))
+	}
+	if !got[0].Equal(errorDiagnostic) {
+		t.Error("expected diagnostic to remain unchanged without known schema context")
+	}
+}
+
+func TestAppendSchemaDiagnosticsUsesOnlyKnownContext(t *testing.T) {
+	t.Parallel()
+
+	errorDiagnostic := diag.NewErrorDiagnostic("Invalid plan", "Plan could not be decoded.")
+
+	var got diag.Diagnostics
+	AppendSchemaDiagnostics(
+		&got,
+		diag.Diagnostics{errorDiagnostic},
+		types.StringValue("orders-value"),
+		types.Int64Unknown(),
+	)
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", len(got))
+	}
+
+	const wantDetail = "Plan could not be decoded.\n\nSchema context: subject \"orders-value\"."
+	if got[0].Detail() != wantDetail {
+		t.Errorf("unexpected error detail:\nwant: %q\n got: %q", wantDetail, got[0].Detail())
+	}
+}


### PR DESCRIPTION
### Description

Credit to @dstrates for identifying that raw framework diagnostics lacked the schema context needed to debug failures.

The schema resource previously appended diagnostics returned by plan, state, and reference conversion operations unchanged. When those operations failed, the resulting message could identify an invalid attribute but not the affected subject or schema version.

This change adds known subject and version values to error details across the schema resource lifecycle. It preserves the original summary and attribute path, leaves warnings unchanged, and falls back to the original diagnostic when neither context value is known.

This only enriches error details; resource state, API behavior, warning output, and Terraform source highlighting are unchanged.

### Relations

Closes #105

### Output from Acceptance Testing

`make testacc` was not run locally because its Redpanda test container requires Docker, which is unavailable in the test environment.

### Additional Validation

```console
go test ./internal/utils -count=1
go test -c -o /tmp/terraform-provider-schemaregistry-provider.test ./internal/provider
go build ./...
go vet ./...
go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run
go mod tidy
```

All completed successfully; `go mod tidy` produced no changes.
